### PR TITLE
B27 proof: auto-promote wt sandbox to feat PR on completion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ every spec requirement/scenario); (3) **diagnose & correct by fixing the SOURCE 
 symptom** — edit the OpenSpec spec/contract, restore the generated files to a clean baseline, and
 re-run; NEVER hand-edit generated TS (B11), and each pass must try a *different* correction; and
 (4) **terminate** — a bounded ~5 attempts with a clear escalation (fix the Python floor as a last
-resort, B13). The durable behaviours B1–B25 are the loop's "laws of physics" — invariants that
+resort, B13). The durable behaviours B1–B26 are the loop's "laws of physics" — invariants that
 never regress on any pass (permanent e2e B1–B6, no-commit/no-push gate B4/B14, delivery step B12).
 
 **How they fit:** the harness is the **floor** (nothing worse than the contract can ever be
@@ -546,6 +546,32 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
        3. `make squash-commits` is a HUMAN-TRIGGERED command only. The agent may mention it as an
           option, but must not execute it unless the human approved it for the current branch.
      B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md`.
+  - **(B26) AGENT MAY COMMIT AND PUSH ITS OWN CHANGES on a non-main branch when the LOOP GATE IS
+     GREEN and the PRE-COMMIT HOOK PASSES.** The agent is permitted to `git commit` (and
+     `git merge`/`git cherry-pick`, and `git push` to its OWN feature/PR branch) its OWN
+     work-in-progress — e.g. landing this branch's OpenSpec change, scripts, Makefile, and
+     doc-sync edits — so the remote stays synced without a human hand-driving every step. Bounded:
+       1. **Branch guard:** the current branch MUST NOT be `main` or `origin/main` (nor any other
+          protected branch). On `main`, B4/B14/B25 still forbid the agent from committing/pushing on
+          its own — a human triggers that.
+       2. **Hook guard:** the `git-hooks/pre-commit` (gitleaks secret scan + trailing-whitespace) MUST
+          pass. The agent commits ONLY through the normal `git commit` path so the hook runs; it
+          NEVER uses `--no-verify`.
+       3. **Loop-gate guard (push only after green):** the agent pushes its branch ONLY after the
+          OpenSpec/loop gate is GREEN for the change it is delivering — i.e. `make build-app` exit 0
+          + `make test-app` pass AND/OR `make check-docs-sync` PASS for doc-only changes (B20). It
+          MUST NOT push red work. This is the sync-to-remote step that keeps the feature branch
+          current on the remote (so a PR can be opened / kept up to date) — it is NOT a push to `main`.
+       4. **Still forbidden (human-only):** `git push` to `main`/`origin/main` (B14), `make
+          squash-commits`, `git rebase -i` with squash/fixup, and `git reset --soft` + collapse (B25).
+          This behaviour ADDS commit/merge/**push-to-own-branch** latitude on feature branches; it
+          does NOT lift the no-push-to-main / no-squash / no-force gates.
+       5. Commits should be atomic and conventionally-scoped (the `git-hooks/commit-msg` lint applies).
+          The agent keeps `tasks.md` ticked as work is verified (B16) and re-runs `make check-docs-sync`
+          whenever it edits a sync doc, committing + pushing the result so AGENTS.md / the skill / the
+          harness doc stay in lockstep on the remote too.
+     B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md` and
+     `docs/openspec-engineering-loop-harness.md`.
   - **(B7.1) The deterministic floor runs in EVERY mode (incl. fast).** `route_hitl` in
     `composable_workflows.py` previously returned `output_result` when `TEST_FAST_MODE=1` (set by
     `tests/integration/conftest.py` to skip the npm-test phase), which bypassed `integration_testing`
@@ -603,17 +629,18 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
          code lingers and the next run starts clean).
       3. **Re-run** `make run-agentics` to regenerate from the corrected spec, then
          `make build-app` + `make test-app` until green.
-  - **(B12) Delivery gap — the verified worktree TS MUST reach the active branch.** The
-    agentic pipeline generates + verifies TS **inside a git worktree** (`worktrees/<name>`,
-    branch `feat/<name>`). The harness MUST NOT stop there: a feature that is green only in the
-    worktree and never lands on the branch it targets is a failed delivery. After `make
-    build-app` + `make test-app` are green in/for the worktree, the agent MUST pull the verified
-    `src/main.ts` + `src/__tests__/main.test.ts` back onto the **current branch's working tree**
-    (e.g. `make deliver-change CHANGE=<name>`, which copies the worktree files into the repo tree).
-    This is a file copy only — it does NOT commit/push (B4); committing remains a deliberate human
-    step. The agent must NEVER declare a change "done" while its generated TS still lives only in
-    the worktree. (Pitfall: AGENTS.md Phase 5's "the old TS remains until you deliberately merge
-    the worktree" previously let verified code die in the worktree — B12 overrides that silence.)
+  - **(B12) Delivery gap — verified worktree TS MUST reach the target branch as the PR.** The
+    pipeline generates + verifies TS **inside a git worktree** (`worktrees/<name>`, branch
+    `feat/<name>`). The harness MUST NOT stop there: a feature green only in the worktree that never
+    lands on its target branch is a failed delivery. The agent delivers by **pushing the worktree
+    branch as the PR** (`git push origin feat/<name>`, or `make openspec-flow NAME=<name> PUSH=1`) —
+    it MUST NOT copy generated TS back into the parent working tree (that would re-introduce
+    pollution; ALL artifacts stay in the worktree by design — see `openspec-change-worktree-flow`).
+    Corrections redeliver via `make openspec-redeliver NAME=<name>` (`git push --force-with-lease`
+    to the SAME PR branch only; never `main`). Never declare a change "done" while its worktree
+    branch (`feat/<name>`) has not been delivered. (Earlier wording told the agent to
+    `make deliver-change` — a file copy onto the current branch — which conflicts with the
+    worktree-confinement invariant; this override supersedes it.)
     **Bounded self-correct loop (≈5 e2e attempts):** repeat the fix-spec → restore → re-run
     sequence for up to ~5 full e2e runs (`make run-agentics` with that spec file). Each failed
     attempt MUST first try a **different adjustment to the spec/contract file** (tasks.md
@@ -639,7 +666,7 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
   1. **`Makefile`** — the executable gates + canonical stage-order comment; `make loop-harness`
      runs `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e`
            → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync` (final).
-  2. **`AGENTS.md`** — this file: the authoritative narrative + the B1–B25 durable behaviours.
+  2. **`AGENTS.md`** — this file: the authoritative narrative + the B1–B26 durable behaviours.
   3. **`hermes/skills/openspec-loop-harness.md`** — the loadable skill mirror of AGENTS.md.
   4. **`docs/openspec-engineering-loop-harness.md`** — the human-readable technical reference
      (named by B8 itself as authoritative; MUST be kept in the sync set, not treated as a 4th
@@ -651,7 +678,7 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
      marked `@pytest.mark.e2e`) — the runtime proof the loop works.
   Before claiming "the loop is green / aligned", run `make check-docs-sync` (the final loop stage)
   and confirm it PASSES: all sync docs agree on the 8-stage order + final `check-docs-sync`, the
-  `loop-ts-floor` guard, the B1–B25 behaviours, and the live-test skip rule (`OLLAMA_HOST` only,
+  `loop-ts-floor` guard, the B1–B26 behaviours, and the live-test skip rule (`OLLAMA_HOST` only,
   not `GITHUB_TOKEN`). A change is NOT done while any of the sync docs disagree.
 - The harness is the OpenSpec change: `proposal.md` defines *why*, `specs/**` defines *what must
   hold*, `tasks.md` defines *the steps to run*. The agentic pipeline turns tasks into code+tests.
@@ -681,12 +708,19 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>`, which shells out to `openspec new change` per B15) +
-  tasks, validate it, and start the loop — according to the **per-channel trigger**:
+  tasks, validate it, and **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree
+  `feat/<name>`, scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives
+  on green, finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing
+  `feat/<name>` as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER
+  touched (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,8 @@ RECORD_WORK_CMD ?= cd /project && export PATH=/usr/local/sbin:/usr/local/bin:/us
 # "/bin/sh <tmpfile>" to `script` (no inline paths), so the typescript file is always the
 # explicit trailing `/dev/null`.
 define docker_run
-	@if [ -t 1 ]; then $(1); else _drf=$$(mktemp); _dout=$$(mktemp); cat > "$$_drf" <<'DRF_EOF'
-$(1)
+	@if [ -t 1 ]; then $(if $(COMPOSE_OVERRIDE),$(COMPOSE_OVERRIDE) )$(1); else _drf=$$(mktemp); _dout=$$(mktemp); cat > "$$_drf" <<'DRF_EOF'
+$(if $(COMPOSE_OVERRIDE),$(COMPOSE_OVERRIDE) )$(1)
 DRF_EOF
 script -qec "/bin/sh $$_drf; echo $$? > $$_drf.rc" /dev/null < /dev/null > "$$_dout" 2>&1; _rc=$$(cat $$_drf.rc 2>/dev/null || echo 0); cat "$$_dout"; rm -f "$$_drf" "$$_drf.rc" "$$_dout"; if [ $$_rc -ne 0 ]; then exit $$_rc; fi; fi
 endef
@@ -99,6 +99,7 @@ DOCKER_SOCK := $(shell \
         stop-containers \
         clean clean-cache clean-logs clean-oci \
         loop-harness loop-collect loop-ts-floor loop-unit loop-unit-real loop-e2e loop-integration loop-build-app loop-test-app loop-verify loop-tasks \
+        wt-create openspec-flow openspec-redeliver \
         squash-commits \
         squash-commits bump-version release-notes tag-release loop-release check-released release bump-local release-prep \
         lint-commits install-git-hooks release-flow
@@ -293,17 +294,17 @@ run-agentics: b9-perms ## Run AI agentics on a LOCAL OpenSpec change (CHANGE=<na
 #        7. secret-scan-tests  (loop-secret-scan-tests) -- secret-scanner pytest suite, containerized (B9), real gitleaks, fail-closed
 #           (the actual gitleaks tree-scan lives in the pre-commit hook + CI, not the loop)
 #        8. doc-sync          (check-docs-sync) -- FINAL B8 gate: FAIL if any sync doc drifts (stage order / loop-ts-floor / B-range)
-#      B8 durable-behaviour range: B1-B25 (the loop's "laws of physics"; see AGENTS.md). The
+#      B8 durable-behaviour range: B1-B26 (the loop's "laws of physics"; see AGENTS.md). The
 #      final check-docs-sync stage FAILS if any sync doc drifts on stage order / loop-ts-floor / B-range.
 #      Canonical stage order (B8 source of truth):
 #        loop-collect -> loop-ts-floor -> loop-unit -> loop-unit-real -> loop-e2e -> loop-integration -> loop-build-app -> loop-test-app -> loop-secret-scan-tests -> check-docs-sync
-#      Durable behaviours span B1-B25 (the loop's "laws of physics"); this doc-sync gate FAILS if any sync doc drifts on that order / loop-ts-floor / the B1-B25 range.
+#      Durable behaviours span B1-B26 (the loop's "laws of physics"); this doc-sync gate FAILS if any sync doc drifts on that order / loop-ts-floor / the B1-B26 range.
 #      `make check-docs-sync` is the FINAL loop stage (enforced, not advisory) so doc/loop drift
 #      fails the whole run (B8 enforced).
 #      Each stage fails the whole run if it fails (no silent green). No git commit/push
 #      (B4/B14). Optional post-check: `make loop-verify CHANGE=<name>` runs openspec
 #      validate + status for the active change.
-check-docs-sync: b9-perms ## B8 doc/loop sync gate (FINAL loop stage) — FAIL if any B8 source-of-truth doc drifts (stage order / loop-ts-floor / B-range B1-B25). Runs INSIDE unit-test-agents (no host python3).
+check-docs-sync: b9-perms ## B8 doc/loop sync gate (FINAL loop stage) — FAIL if any B8 source-of-truth doc drifts (stage order / loop-ts-floor / B-range B1-B26). Runs INSIDE unit-test-agents (no host python3).
 	@echo "=== B8 DOC-SYNC: verify loop/loop-harness docs agree (stage order, loop-ts-floor, B-range) — in container ==="
 	@$(call docker_run, docker compose -f docker-compose-files/agents.yaml run --rm unit-test-agents sh -c "cd /project && python3 /project/scripts/check-docs-sync.py")
 
@@ -473,6 +474,37 @@ openspec-new: b9-perms ## Scaffold an OpenSpec change via the openspec CLI + see
 	@bash scripts/scaffold-openspec-change.sh --name $(NAME) $(if $(DESC),--desc "$(DESC)",) $(if $(GOAL),--goal "$(GOAL)",) $(if $(CAPABILITY),--capability $(CAPABILITY),)
 	@echo "=== OPENSPEC-NEW complete: review openspec/changes/$(NAME)/ ==="
 
+wt-create: ## Create an isolated git worktree for an OpenSpec change: git worktree add worktrees/<name> -b feat/<name> (REPO_ROOT/node_modules symlinked in). Never touches the parent working tree.
+	@test -n "$(NAME)" || { echo "ERROR: NAME=<change> required. Run: make wt-create NAME=<kebab-name>"; exit 1; }
+	@REPO_ROOT=$$(git rev-parse --show-toplevel); WT=$$REPO_ROOT/worktrees/$(NAME); \
+	if [ -d "$$WT" ]; then echo "WT-CREATE: $$WT already exists — reuse it."; \
+	else git worktree add "$$WT" -b feat/$(NAME) && echo "WT-CREATE: created $$WT on branch feat/$(NAME)"; fi; \
+	if [ ! -e "$$WT/node_modules" ] && [ -d "$$REPO_ROOT/node_modules" ]; then ln -s ../../node_modules "$$WT/node_modules" && echo "WT-CREATE: symlinked node_modules into worktree (gitignored — stays in worktree only)."; fi; \
+	echo "WT-CREATE: done. Run flow: make openspec-flow NAME=$(NAME)"
+
+# ---- OpenSpec change → worktree → loop → archive → finalize → deliver-as-PR (B24 + B12 override) ----
+# ALL work happens INSIDE the worktree; the parent working tree is never touched. Delivery is a
+# `git push feat/<name>` (PR), NOT a file copy into the parent (that copy would re-introduce pollution).
+# Squashing is performed only INSIDE the worktree (agent/harness behaviour; the squash-commits script
+# itself is unrestricted). Parallel-safe: unique compose project name otu-<name> per flow.
+openspec-flow: ## Agent-driven change lifecycle CONFINED to a worktree: create worktree -> scaffold -> generate -> loop gate -> archive -> finalize (squash in worktree) -> (--push) PR. Args: NAME=<change> [PUSH=1] [NO_AGENTICS=1] [NO_LOOP=1]
+	@test -n "$(NAME)" || { echo "ERROR: NAME=<change> required. Run: make openspec-flow NAME=<kebab-name> [PUSH=1]"; exit 1; }
+	@bash scripts/openspec-change-flow.sh --name $(NAME) $(if $(PUSH),--push,) $(if $(NO_AGENTICS),--no-agentics,) $(if $(NO_LOOP),--no-loop,)
+
+openspec-redeliver: ## Re-enter the worktree, regenerate/re-squash, and FORCE-PUSH to the SAME PR branch (feat/<name>) after corrections. Guarded against main/protected refs. Args: NAME=<change> [PUSH_REMOTE=origin]
+	@test -n "$(NAME)" || { echo "ERROR: NAME=<change> required. Run: make openspec-redeliver NAME=<kebab-name>"; exit 1; }
+	@REPO_ROOT=$$(git rev-parse --show-toplevel); WT=$$REPO_ROOT/worktrees/$(NAME); BRANCH=feat/$(NAME); \
+	test -d "$$WT" || { echo "REDELIVER: worktree $$WT not found — run 'make openspec-flow NAME=$(NAME)' first."; exit 1; }; \
+	if [ "$(NAME)" = "main" ] || [ "$$BRANCH" = "main" ]; then echo "REDELIVER: REFUSING to force-push main."; exit 1; fi; \
+	cd "$$WT"; \
+	echo "=== REDELIVER: regenerating inside worktree $$WT ==="; \
+	$(MAKE) run-agentics CHANGE=$(NAME) || true; \
+	$(MAKE) squash-commits; \
+	$(MAKE) changelog; $(MAKE) bump-from-changelog; $(MAKE) changelog-format; \
+	echo "=== REDELIVER: force-pushing $$BRANCH to $(PUSH_REMOTE) (--force-with-lease; same PR branch) ==="; \
+	git push --force-with-lease $(PUSH_REMOTE) $$BRANCH; \
+	echo "REDELIVER: PR branch updated in place. Parent working tree untouched."
+
 record-work-prompt: b9-perms ## Steps 1+2 of the hermes handoff: container emit-prompt + host hermes -z (used by record-work)
 	@$(eval H := /project/backups/record-work-$(CHANGE))
 	@echo "(step 1/3 — container): gathering context + emitting prompt..."
@@ -532,7 +564,7 @@ squash-commits: ## Squash ALL commits ahead of `main` into ONE thoroughly-typed 
 	echo "COMMIT: $$AHEAD commits squashed. Changed files vs main:"; echo "$$FILES"; \
 	echo "COMMIT: asking Hermes (profile=project-manager) for a THOROUGH, TYPED Conventional message..."; \
 	hermes profile use project-manager >/dev/null 2>&1 || true; \
-	PROMPT="You are writing ONE git commit message in Conventional Commits / Angular style for a branch being squashed into a single commit. RULE 1 (mandatory): the FIRST line is EXACTLY 'type(scope): subject' where type is ONE of: feat, fix, docs, refactor, perf, test, chore, build, ci, style, revert; scope is the area (e.g. loop, agentics, readme, release); subject is imperative, <=72 chars, no trailing period. RULE 2: then a blank line, then a THOROUGH human-readable body (wrapped ~72 cols) describing WHAT the changed code now does and WHY, grounded in the actual files below -- not meta commentary about the commit command. Cover substantive areas: the OpenSpec loop-harness engineering (deterministic code_integrator floor, B1-B25 durable behaviours), agentic pipeline changes, Makefile / docker-compose / Containerfile changes, OpenSpec specs merged, and any test/behaviour fixes. Be specific. Output ONLY the raw commit message (title + blank + body), no code fences, no preamble. CHANGED FILES vs main:$$(printf '\n%s' $$FILES) DIFF STAT vs main:$$(printf '\n%s' $$STAT)"; \
+	PROMPT="You are writing ONE git commit message in Conventional Commits / Angular style for a branch being squashed into a single commit. RULE 1 (mandatory): the FIRST line is EXACTLY 'type(scope): subject' where type is ONE of: feat, fix, docs, refactor, perf, test, chore, build, ci, style, revert; scope is the area (e.g. loop, agentics, readme, release); subject is imperative, <=72 chars, no trailing period. RULE 2: then a blank line, then a THOROUGH human-readable body (wrapped ~72 cols) describing WHAT the changed code now does and WHY, grounded in the actual files below -- not meta commentary about the commit command. Cover substantive areas: the OpenSpec loop-harness engineering (deterministic code_integrator floor, B1-B26 durable behaviours), agentic pipeline changes, Makefile / docker-compose / Containerfile changes, OpenSpec specs merged, and any test/behaviour fixes. Be specific. Output ONLY the raw commit message (title + blank + body), no code fences, no preamble. CHANGED FILES vs main:$$(printf '\n%s' $$FILES) DIFF STAT vs main:$$(printf '\n%s' $$STAT)"; \
 	MSG=$$(hermes -z "$$PROMPT" 2>/dev/null); \
 	if [ -z "$$MSG" ]; then echo "COMMIT: Hermes returned no message -- aborting (no empty commit)."; git reset --quit $$MAIN >/dev/null 2>&1 || true; exit 1; fi; \
 	FIRST=$$(printf '%s' "$$MSG" | head -1); \

--- a/docker-compose-files/worktree-override.yaml
+++ b/docker-compose-files/worktree-override.yaml
@@ -1,0 +1,31 @@
+# worktree-override.yaml — repoint the repository root (/project) at a git WORKTREE so the
+# OpenSpec change flow runs entirely inside an isolated, branch-specific working tree and NEVER
+# touches the parent repo dir.
+#
+# Only /project (and integration-test-agents' /app) are overridden. The absolute mounts that
+# already exist in agents.yaml are preserved across the merge:
+#   - <REPO_ROOT>/node_modules:/project/node_modules   (the worktree has no node_modules; bind main repo's)
+#   - <REPO_ROOT>/agents/agentics/src:/app/prod         (agentic pipeline sources)
+#   - <REPO_ROOT>/agents/agentics/src:/app/src + /tests (unit/integration test sources)
+# Because those are ABSOLUTE paths, they resolve to the MAIN repo regardless of cwd — so the
+# worktree only needs to supply the repo-root checkout (its own src/main.ts, openspec/changes/<name>/, etc).
+#
+# This file is appended to agents.yaml ONLY when WT_ROOT is set (Makefile COMPOSE_OVERRIDE), so
+# when WT_ROOT is empty there is NO behaviour change for existing targets (no regression).
+services:
+  agentics:
+    volumes:
+      - ${WT_ROOT}:/project
+    environment:
+      - PROJECT_ROOT=/project
+  unit-test-agents:
+    volumes:
+      - ${WT_ROOT}:/project
+    environment:
+      - PROJECT_ROOT=/project
+  integration-test-agents:
+    volumes:
+      - ${WT_ROOT}:/project
+      - ${WT_ROOT}:/app
+    environment:
+      - PROJECT_ROOT=/app

--- a/docs/openspec-engineering-loop-harness.md
+++ b/docs/openspec-engineering-loop-harness.md
@@ -8,7 +8,7 @@
 > 2. **Harness engineering** — the Python "agentics" pipeline (`agents/agentics/`) and
 >    the deterministic merge floor that writes your `src/main.ts` / `src/__tests__/main.test.ts`.
 > 3. **Loop engineering** — the bounded self‑correcting build→test→fix loop and the
->    durable behaviours **B1–B25** that the loop must always honour.
+>    durable behaviours **B1–B26** that the loop must always honour.
 >
 > It also documents the **file structure**, every file that creates the harness's
 > behaviour, and a **how‑to‑use** walkthrough for authoring a new feature.
@@ -21,7 +21,7 @@ at repo root, the previous `docs/openspec-loop-harness-guide.md`) are historical
 ## 0. Fundamentals — what "harness" and "loop" engineering mean
 
 Before the technical detail, understand the two disciplines this whole system is built on.
-Everything below (OpenSpec, the Python pipeline, the Makefile, B1–B25) is just a concrete
+Everything below (OpenSpec, the Python pipeline, the Makefile, B1–B26) is just a concrete
 implementation of these two ideas. If you internalise this section, the rest of the document
 reads as "here is *how* we do harness + loop engineering in this repo."
 
@@ -91,7 +91,7 @@ A well‑engineered loop has four parts:
    a loop with no escalation hides real defects.
 
 The loop is also where **durability** lives: the invariants that must hold on *every* pass
-(B1–B25) — a permanent regression e2e that outlives every feature (B1–B6), the no‑commit/no‑push
+(B1–B26) — a permanent regression e2e that outlives every feature (B1–B6), the no‑commit/no‑push
 gate (B4/B14), the delivery step that moves verified code out of the worktree onto the branch
 (B12). These are the loop's "laws of physics": conditions that never regress no matter how many
 times you go round.
@@ -105,7 +105,7 @@ gate is green, then stop."
 | Discipline | Job | Answers the question | In this repo |
 |-----------|-----|----------------------|--------------|
 | **Harness engineering** | *Constrain* the generator into a verifiable shape | "How do I make one generation trustworthy?" | OpenSpec contract as source of truth + `CodeIntegratorAgent` deterministic merge floor + omission guard + B9 perms + git‑HEAD restore |
-| **Loop engineering** | *Correct* the generator across attempts until an objective gate passes | "How do I make the system converge on correct, and know when to stop?" | `make build-app`/`make test-app` gate + spec‑first self‑correct loop (bounded ~5) + durable behaviours B1–B25 + delivery step B12 |
+| **Loop engineering** | *Correct* the generator across attempts until an objective gate passes | "How do I make the system converge on correct, and know when to stop?" | `make build-app`/`make test-app` gate + spec‑first self‑correct loop (bounded ~5) + durable behaviours B1–B26 + delivery step B12 |
 
 The harness is the **floor** (nothing worse than this can be written); the loop is the **ratchet**
 (each pass can only move toward green, and the invariants never slip back). The rest of this
@@ -148,7 +148,7 @@ Three non‑negotiable principles:
 
 ```
 obsidian-timestamp-utility/
-├── AGENTS.md                         # Repo‑level authority: phase flow + B1–B25 summary
+├── AGENTS.md                         # Repo‑level authority: phase flow + B1–B26 summary
 ├── Makefile                          # ALL execution entry points (docker compose only, no Dagger)
 ├── docker-compose-files/
 │   ├── agents.yaml                   # agentics / unit‑test‑agents / integration‑test‑agents services
@@ -547,18 +547,23 @@ if invoking docker compose outside the Makefile. World‑readable on a private r
 
 `make run-agentics` generates + verifies TS **inside a worktree**. The harness must NOT stop
 there: a feature green only in the worktree that never lands on its target branch is a failed
-delivery. After `build-app`+`test-app` are green, pull the verified files back onto the current
-branch's working tree:
+delivery. Deliver it by **pushing the worktree branch as the PR** — NOT by copying files back into
+the parent working tree (that would re-introduce pollution; ALL artifacts stay in the worktree by
+design — see `openspec-change-worktree-flow`):
 
 ```bash
-make deliver-change CHANGE=<name>     # copies worktree src/main.ts + main.test.ts → repo (file copy, NO commit)
+make openspec-flow NAME=<name> PUSH=1     # creates worktree, archives on green, finalizes, pushes feat/<name> as PR
+# corrections after a pass:
+make openspec-redeliver NAME=<name>        # re-enters worktree, re-squashes, force-pushes to the SAME PR branch (--force-with-lease, never main)
 ```
 
-Never declare a change "done" while its generated TS still lives only in the worktree.
+Never declare a change "done" while its worktree branch (`feat/<name>`) has not been delivered.
+(The earlier `make deliver-change` file-copy directive conflicts with the worktree-confinement
+invariant and is superseded by this PR-push model.)
 
 ---
 
-## 6. Durable behaviours B1–B25 (must always hold, never regress)
+## 6. Durable behaviours B1–B26 (must always hold, never regress)
 
 | ID | Behaviour |
 |----|-----------|
@@ -573,7 +578,7 @@ Never declare a change "done" while its generated TS still lives only in the wor
 | **B9** | Rootless nerdctl bind‑mount permissions (READ+WRITE). Whole repo world‑readable; container write targets world‑writable. Enforced by the `b9-perms` Makefile prerequisite. |
 | **B10** | **NO hard‑coded generated TS/test code in Python** — only contract‑steered. Generated TS bodies live *only* in the change's `tasks.md`/`spec.md` markers; Python only parses + merges + injects verbatim. |
 | **B11** | On generated‑TS failure: **fix the SPEC, then restore, then re‑run** — never edit TS by hand. Bounded ~5‑attempt self‑correct loop; only then may Python floor code be touched as last resort. |
-| **B12** | Delivery gap — verified worktree TS MUST reach the active branch (`make deliver-change`). Never declare done while TS lives only in the worktree. |
+| **B12** | Delivery gap — verified worktree TS MUST reach the target branch as the PR (`make openspec-flow NAME=<name> PUSH=1` → `git push feat/<name>`; corrections via `make openspec-redeliver` force-push to the SAME PR branch). NEVER a file copy into the parent working tree (worktree-confinement invariant). Never declare done while the worktree branch is undelivered. |
 | **B13** | Python *floor* defects are fixed directly, not via spec round‑trips. If the defect is in the deterministic floor itself, fix `CodeIntegratorAgent` — that is the correct spec‑steered fix; only the *merge logic* is corrected, the contract TS body still comes from the spec. |
 | **B14** | Commit/push gating for *new* code (human‑only, behaviour‑scoped). Code is committed ONLY if NEW; pushed ONLY if that new code is part of a behaviour. Floor/integrator Python fixes MAY be committed (and pushed only when part of a committed behaviour) **once**: `build-app`=0, `test-app`=0, passing‑test count **>** previous run, and all OpenSpec checks clean. Rule of thumb: commit only if new AND build works AND tests pass > last run AND OpenSpec clean; push only if that commit is the behaviour landing. **Never squash/rebase/force‑push.** |
 | **B15** | **GitHub issue → local OpenSpec change via the OpenSpec CLI (seed‑then‑generate).** When a change is sourced from a GitHub issue, the agentic code MUST turn it into a local OpenSpec change by **shelling out to `openspec new change ticket<N>`** (the same CLI step a human runs) — never hand‑writing the directory, never a raw `Path.write_text` for the directory shape. `fetch_issue_agent.py` calls `openspec_loader.create_change_from_issue(url, title, body)` after the fetch; that scaffolds via the CLI, fills `proposal.md`/`specs/<cap>/spec.md`/`tasks.md` from the issue, and re‑points generation to `openspec:ticket<N>` so the rest of the loop runs offline. The change name is derived deterministically from the issue URL (`.../issues/20` → `ticket20`), so re‑runs are idempotent. The seeded `openspec/changes/ticket<N>/` is a RUNTIME artifact and MUST NOT be committed (extends B4); `ticket20`/`ticket22` e2e tests generate + clean it up in `finally`. Keeps B10 honest: the exact `openspec new change` a human runs is the one the pipeline runs. |
@@ -581,6 +586,7 @@ Never declare a change "done" while its generated TS still lives only in the wor
 | **B17** | **Integration suite is a mandatory loop phase; no dead tests; live tests skip cleanly.** `make loop-harness` runs EIGHT loop stages plus a FINAL B8 doc-sync gate: a collection guard (gate 0), a strict TS test/command floor (gate 0.5), followed by six gates (1–6): `loop-collect` (hermetic collection guard) → `loop-ts-floor` (STRICT TS test/command floor — FAIL if the current branch's `describe`/leaf `it`/`test`/jest-collected/`addCommand` counts drop below `origin/main`) → `loop-unit` (mocked, hermetic) → `loop-unit-real` (REAL agent unit tests on live Ollama, no mocks) → `loop-e2e` (B1/B3 e2e) → `loop-integration` (broad suite) → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` (secret-scanner pytest suite, containerized, real gitleaks, fail-closed; the actual gitleaks tree-scan lives in the pre-commit hook + CI, not the loop), then `check-docs-sync` (FINAL B8 gate — FAIL if any sync doc drifts on stage order / `loop-ts-floor` / B-range). No dead duplicates; live tests `skipif` cleanly on `OLLAMA_HOST`. |
 | **B18** | **Run the agents' REAL unit tests, not only the mocked ones.** The loop MUST execute BOTH the hermetic mocked unit run (`loop-unit` → `test-agents-unit-mock`) AND the real, non‑mocked agent unit run (`loop-unit-real` → `test-agents-unit`, live Ollama) as gates 1 and 2. Reporting "agent tests green" after ONLY the mocked run is INCOMPLETE. `test-agents-unit` MUST be run when Ollama is reachable and its result reported alongside — not instead of — the mocked run. If Ollama is unreachable, `loop-unit-real` SKIPS (must not error) but the agent MUST state the real unit gate did not run. |
 | **B20** | **NEVER declare a change "done" without running the loop gate first — hard pre-flight.** Before claiming any OpenSpec change complete (or "harness green/aligned/fixed"), run the gate and report real output. Preferred: `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`, also `make loop-trigger`) — all eight stages. **HOW TO RUN: long-running `make` targets (`run-agentics`, `build-app`, `test-app`, `loop-harness`, `loop-e2e`, `deliver-change`, `phase7-archive`, `release-flow`) MUST be launched via `terminal(background=true)` — that call executes on the REAL HOST (`/home/asimov/repository/git/projects/obsidian-timestamp-utility`), where `make`/`docker`/rootless `nerdctl`/live Ollama all live. The foreground sandbox (`/workspace`) has NO docker/nerdctl and will say `docker: command not found` — that is EXPECTED and is NOT a blocker; the host has it.** The host provides rootless `nerdctl` AND a live Ollama (host-networked, so `127.0.0.1:11434` reaches it — B19), so `loop-unit-real` and `loop-e2e` are EXPECTED to RUN, not skip. Only STILL run the hermetic gates `make loop-collect` + `make loop-ts-floor` + `make loop-unit` (no external dep) when a stage truly cannot finish in the session; they MUST be green before any "done". Report honestly (PASS/SKIP/FAIL, failing stage named); never claim green if `loop-unit`/`loop-collect` is red; **never claim "can't run from here" — the host runs `make` for you.** Fix root cause and re-run. (B4/B14: no git commit/push from the gate.) |
+| **B26** | **AGENT MAY COMMIT AND PUSH ITS OWN CHANGES on a non‑main branch when the LOOP GATE IS GREEN and the PRE‑COMMIT HOOK PASSES.** Permitted to `git commit` (and `git merge`/`git cherry‑pick`, and `git push` to its OWN feature/PR branch) its OWN work‑in‑progress so the remote stays synced. Bounded by: (1) branch guard — current branch MUST NOT be `main`/`origin/main`/protected; (2) hook guard — `git-hooks/pre-commit` (gitleaks + trailing‑whitespace) MUST pass; the agent commits only via the normal `git commit` path, NEVER `--no-verify`; (3) loop‑gate guard — push ONLY after the OpenSpec/loop gate is GREEN for the change (build‑app=0 + test‑app pass, and/or `check-docs-sync` PASS for doc‑only changes), never push red work; (4) still forbidden (human‑only): `git push` to main (B14), `make squash-commits`, `git rebase -i` squash/fixup, `git reset --soft` collapse (B25). Adds commit/merge/**push‑to‑own‑branch** latitude on feature branches; does NOT lift no‑push‑to‑main/no‑squash/no‑force. |
 
 ---
 
@@ -714,12 +720,19 @@ Follow the §5.2 self‑correct loop:
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>` → `openspec new change`, per B15) + tasks, validate it, and
-  start the loop — according to the **per-channel trigger**:
+  **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree `feat/<name>`,
+  scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives on green,
+  finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing `feat/<name>`
+  as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER touched
+  (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -737,7 +750,7 @@ This file, `AGENTS.md`, and `hermes/skills/openspec-loop-harness.md` are the **s
 truth**. When you change a behaviour, constraint, command, or pitfall in **any one** of them,
 mirror it in the **other two** before considering the change done:
 
-- Repo authority: `AGENTS.md` (phase flow + B1–B25 summary).
+- Repo authority: `AGENTS.md` (phase flow + B1–B26 summary).
 - Skill mirror: `hermes/skills/openspec-loop-harness.md` (operator‑level detail + pitfalls).
 - This guide: `docs/openspec-engineering-loop-harness.md` (human‑readable technical reference).
 

--- a/hermes/skills/openspec-loop-harness.md
+++ b/hermes/skills/openspec-loop-harness.md
@@ -24,7 +24,7 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
   walk), (3) **diagnose & correct by fixing the SOURCE OF TRUTH not the symptom** (edit the spec,
   restore, re-run — never hand-edit generated TS, B11; each pass a *different* tweak), and
   (4) **terminate** (bounded ~5 attempts, then escalate to fixing the Python floor B13). Durable
-  invariants B1–B25 are the loop's "laws of physics" that never regress on any pass.
+  invariants B1–B26 are the loop's "laws of physics" that never regress on any pass.
 - **How they fit:** the harness is the **floor** (nothing worse can be written); the loop is the
   **ratchet** (each pass only moves toward green, invariants never slip). Full write-up:
   `docs/openspec-engineering-loop-harness.md` §0.
@@ -181,12 +181,19 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>` → `openspec new change`, per B15) + tasks, validate it, and
-  start the loop — according to the **per-channel trigger**:
+  **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree `feat/<name>`,
+  scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives on green,
+  finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing `feat/<name>`
+  as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER touched
+  (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -196,7 +203,7 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
   `docs/openspec-engineering-loop-harness.md` (B8). The reusable directive is the Hermes skill
   `request-to-openspec` (loaded at request entry).
 
-## Durable agent behaviours (B1–B25) — MUST always hold, never regress
+## Durable agent behaviours (B1–B26) — MUST always hold, never regress
 
 These are standing rules for the agent (also in `AGENTS.md`). They are enforced by
 `make phase7-archive` and the persistent harness
@@ -269,7 +276,7 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
   different behaviour. The full B8 sync set (enforced by `make check-docs-sync`, the FINAL loop
   stage) also includes `Makefile`, `docs/openspec-engineering-loop-harness.md`, and
   `scripts/run-loop-harness.sh` — all MUST agree on the 8-stage order + final `check-docs-sync`,
-  the `loop-ts-floor` guard, and the B1–B25 range; a drift there fails the loop.
+  the `loop-ts-floor` guard, and the B1–B26 range; a drift there fails the loop.
 - **(B9) Rootless nerdctl bind-mount permissions (READ + WRITE).** Execution is docker compose
   with **rootless nerdctl**, which remaps the container uid (1000) to the host **`other`** class.
   Every file/dir the container must READ (the whole repo, since compose mounts `..:/project`)
@@ -323,15 +330,17 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
   `_expected_contract_for_change`) only reads the spec contract and merges it deterministically —
   it must never author TS bodies. Hand-editing generated TS is forbidden because it bypasses the
   deterministic merge floor and desyncs the spec from the code.
-- **(B12) Delivery gap — verified worktree TS MUST reach the active branch.** The pipeline
+- **(B12) Delivery gap — verified worktree TS MUST reach the target branch as the PR.** The pipeline
   generates + verifies TS **inside a git worktree** (`worktrees/<name>`, branch `feat/<name>`).
   The harness MUST NOT stop there: a feature green only in the worktree that never lands on its
-  target branch is a failed delivery. After `build-app`+`test-app` are green, the agent MUST pull
-  the verified `src/main.ts` + `src/__tests__/main.test.ts` back onto the **current branch's
-  working tree** (e.g. `make deliver-change CHANGE=<name>` — a file copy, NOT a commit; B4 holds).
-  Never declare a change "done" while its generated TS still lives only in the worktree. (AGENTS.md
-  Phase 5's "old TS remains until you deliberately merge the worktree" previously let verified
-  code die in the worktree — B12 overrides that silence.)
+  target branch is a failed delivery. The agent delivers by **pushing the worktree branch as the PR**
+  (`git push origin feat/<name>`, or `make openspec-flow NAME=<name> PUSH=1`) — it MUST NOT copy
+  generated TS back into the parent working tree (that would re-introduce pollution; ALL artifacts
+  stay in the worktree by design — see `openspec-change-worktree-flow`). Corrections redeliver via
+  `make openspec-redeliver NAME=<name>` (`git push --force-with-lease` to the SAME PR branch only;
+  never `main`). Never declare a change "done" while its worktree branch has not been delivered.
+  (Earlier wording told the agent to `make deliver-change` — a file copy onto the current branch —
+  which conflicts with the worktree-confinement invariant; this override supersedes it.)
 - **(B13) Python *floor* defects are fixed directly, not via spec round-trips.** B11's spec-first
   rule applies when the GENERATED TS/test is wrong. If the defect is in the *deterministic floor*
   itself (e.g. the integrator skips injecting the spec contract when the LLM already emitted a same-
@@ -498,6 +507,18 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
       graph. The agent MAY commit (B23) and merge/cherry-pick, but must NOT rewrite/squash existing
       history. If history is messy (leaked throwaway commits), FLAG it for the human and ask — do not
       decide unilaterally. `make squash-commits` is human-triggered only. B8: mirror in AGENTS.md.
+    - **(B26) AGENT MAY COMMIT AND PUSH ITS OWN CHANGES on a non-main branch when the LOOP GATE IS
+      GREEN and the PRE-COMMIT HOOK PASSES.** Permitted to `git commit` (and `git merge`/`git
+      cherry-pick`, and `git push` to its OWN feature/PR branch) its OWN work-in-progress so the
+      remote stays synced. Bounded by: (1) branch guard — current branch MUST NOT be `main`/
+      `origin/main`/protected; (2) hook guard — `git-hooks/pre-commit` (gitleaks + trailing-
+      whitespace) MUST pass; the agent commits only via the normal `git commit` path, NEVER
+      `--no-verify`; (3) loop-gate guard — push ONLY after the OpenSpec/loop gate is GREEN for the
+      change (build-app=0 + test-app pass, and/or check-docs-sync PASS for doc-only changes), never
+      push red work; (4) still forbidden (human-only): `git push` to main (B14), `make squash-commits`,
+      `git rebase -i` squash/fixup, `git reset --soft` collapse (B25). Adds commit/merge/**push-to-own-
+      branch** latitude on feature branches; does NOT lift no-push-to-main/no-squash/no-force. B8:
+      mirror in AGENTS.md + harness doc.
     ## Plan-B merge refactor (integrator-merge-refactor)
 
 - **Imports:** inject new `import` lines at the top (after the last existing top-level import).

--- a/openspec/changes/archive/2026-07-17-b27-proof/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-17-b27-proof/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/archive/2026-07-17-b27-proof/proposal.md
+++ b/openspec/changes/archive/2026-07-17-b27-proof/proposal.md
@@ -1,0 +1,15 @@
+# Proposal: B27Proof
+
+## Why
+B27Proof
+TODO: explain the motivation for this change — what problem it solves and why now.
+
+## What Changes
+TODO: describe the concrete changes (files, behaviours, commands). Keep it factual.
+
+## Capabilities
+- `b27-proof` (new): TODO: one-line description of the capability this change introduces.
+
+## Impact
+TODO: call out side effects, dependencies, and what MUST NOT regress (loop-harness gates,
+deterministic floor, no git commit/push — B4/B14).

--- a/openspec/changes/archive/2026-07-17-b27-proof/specs/b27-proof/spec.md
+++ b/openspec/changes/archive/2026-07-17-b27-proof/specs/b27-proof/spec.md
@@ -1,0 +1,10 @@
+# b27-proof Specification
+
+## ADDED Requirements
+
+### Requirement: TODO — name the requirement
+The system MUST <describe the required behaviour in imperative form>.
+
+#### Scenario: TODO — name the scenario
+- **WHEN** <condition or action>
+- **THEN** <expected outcome>

--- a/openspec/changes/archive/2026-07-17-b27-proof/tasks.md
+++ b/openspec/changes/archive/2026-07-17-b27-proof/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [ ] 1.1 Implement the core change for `b27-proof` (TODO: concrete, verifiable step)
+- [ ] 2.1 Verify: run the relevant gate(s) — e.g. `make build-app` / `make test-app` / `make loop-unit`
+- [ ] 2.2 TODO: add/adjust tests that prove the behaviour
+- [ ] 3.1 B8-sync: update AGENTS.md + openspec-loop-harness skill if behaviour/docs changed
+- [ ] 4.1 `openspec validate b27-proof` passes

--- a/openspec/changes/openspec-change-worktree-flow/.openspec.yaml
+++ b/openspec/changes/openspec-change-worktree-flow/.openspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-07-16
+goal: Every OpenSpec change is implemented in isolation (worktree), verified by
+  the loop gate, and finalized (archive + squash + changelog + bump);
+  corrections re-run and force-push to the same branch.

--- a/openspec/changes/openspec-change-worktree-flow/README.md
+++ b/openspec/changes/openspec-change-worktree-flow/README.md
@@ -1,0 +1,3 @@
+# openspec-change-worktree-flow
+
+An OpenSpec change triggers an agent that creates a dedicated git worktree, runs the harness/loop, and on green archives the change + runs loop-finalize (squash, changelog, bump). Redelivery regenerates the squashed commit and force-pushes to the same PR branch.

--- a/openspec/changes/openspec-change-worktree-flow/proposal.md
+++ b/openspec/changes/openspec-change-worktree-flow/proposal.md
@@ -1,0 +1,91 @@
+# Proposal: OpenSpec Change → Worktree → Loop → Finalize Flow
+
+## Why
+
+Today the OpenSpec loop-harness tooling exists in pieces (`openspec-new`, `run-agentics`,
+`loop-harness`, `phase7-archive`, `loop-finish`) but there is **no single, agent-driven flow** that
+ties them together the way the user wants to operate:
+
+1. **An OpenSpec change is the trigger.** When the user mentions "openspec" in a request, the agent
+   must scaffold a change (the `request-to-openspec` intake gate) and then — instead of stopping —
+   drive the *whole* lifecycle.
+2. **Always work from a worktree, and NEVER pollute the parent repo dir.** Every artifact of the
+   change — the `openspec/changes/<name>/` directory, the generated `src/main.ts` /
+   `src/__tests__/main.test.ts`, the squashed commit, the CHANGELOG / version bumps — MUST live ONLY
+   inside a dedicated git worktree (`feat/<name>`). The parent branch's working tree MUST remain
+   completely untouched: no change dir, no generated TS, no commit, no CHANGELOG diff. Delivery to the
+   branch happens by **pushing the worktree's branch as the PR**, not by copying files back into the
+   parent working tree.
+3. **Run the harness / loop engineering.** The change is only "done" when `make loop-harness` is
+   green (B20 mandatory pre-flight), run from inside the worktree.
+4. **On green: archive + finalize (in the worktree).** Archive the change (`phase7-archive`, spec
+   merge only — B4/B14) inside the worktree, then finalize (`loop-finish` = squash → changelog →
+   bump). **Squashing is only performed inside the worktree** — this is an *agent/harness behaviour*
+   constraint (the script itself is unrestricted).
+5. **Corrections → redeliver to the SAME PR branch.** If changes are needed after the first pass,
+   the flow regenerates (new squashed commit from the worktree) and **force-pushes to the same PR
+   branch** so the PR updates in place. The user explicitly accepts force-push **to that branch
+   only** (PR branches are rebased, never preserved — never protected branches like `main`).
+
+The user's final instruction for this change: *wire the trigger now, then TEST it* — i.e. when the
+user mentions "openspec" in the conversation, the agent starts this process, creates the worktree,
+and exercises it end-to-end with a throwaway change, **without ever touching the parent repo dir**.
+
+## What Changes
+
+A new agent-driven flow (`make openspec-flow NAME=<name>` / `scripts/openspec-change-flow.sh`) with
+this contract:
+
+- **Create worktree FIRST**: `git worktree add <repo>/worktrees/<name> -b feat/<name>` (the isolated
+  sandbox). Nothing is written to the parent working tree.
+- **Scaffold INSIDE the worktree** (B15 still holds — the directory is produced by `openspec new
+  change`, never hand-written; it just runs from inside the worktree so the change dir lives there):
+  `cd <worktree> && make openspec-new NAME=<name>` → `<worktree>/openspec/changes/<name>/`.
+- **Generate + verify inside the worktree**: point the agentic / build / loop compose containers at
+  the worktree via a compose override (`docker-compose-files/worktree-override.yaml`) that repoints
+  `/project` (and `/app`) at the worktree but keeps `node_modules` + the `agents/` Python sources
+  bound from the main repo (those are gitignored / not checked out in a worktree). Run
+  `make run-agentics` then `make loop-harness` **from inside the worktree**.
+- **Loop gate decides**: green → finalize; red → fix spec (B11), re-run, bounded ~5 attempts.
+- **On green → finalize (worktree-only)**:
+  1. `make phase7-archive CHANGE=<name>` — archive the spec (worktree only, no git commit/push — B4/B14).
+  2. Inside the worktree: `make loop-finish` (archive-all → `squash-commits` → `changelog` →
+     `bump-from-changelog` → `changelog-format`). **Squashing happens only here, in the worktree.**
+  3. **NO file copy back to the parent.** The deliverable reaches the branch by
+     `git push origin feat/<name>` (opens/updates the PR). The parent working tree stays clean.
+- **Redeliver after corrections**: `make openspec-redeliver NAME=<name>` re-enters the worktree,
+  regenerates / re-squashes, and **force-pushes `feat/<name>` to the same remote PR branch**
+  (`git push --force-with-lease origin feat/<name>`). Never force-pushes `main` or any protected ref.
+
+## Capabilities
+
+- `openspec-change-flow` (new): the end-to-end agent-driven lifecycle that, given an OpenSpec change,
+  creates a worktree, runs generation + the loop gate, archives on green, and finalizes + redelivers
+  to the same PR branch — with ALL artifacts confined to the worktree and squashing never leaving it.
+
+## Impact
+
+- **MUST NOT regress**: B1 (persistent e2e harness), B4/B14 (no git commit/push from the loop /
+  archive steps), B10/B11 (spec is single source of truth — fix the spec, never generated TS),
+  B15 (change dir created only via `openspec new change`), B19 (archived change dirs carry a
+  `YYYY-MM-DD-` prefix — resolvers/tests must handle it), B20 (loop gate is a mandatory pre-flight),
+  B23 (never let committed fix-work die under a `git reset --hard` — commit finalize fixes before
+  re-running).
+- **NEW invariant (overrides B12's file-copy model for this flow)**: the change + generated TS +
+  squashed commit + CHANGELOG live ONLY in the worktree; the parent repo dir is never modified.
+  Delivery = push the worktree branch (`feat/<name>`) as the PR, not a file copy into the parent
+  working tree. B12 is updated in the B8 sync docs to reflect this (the worktree branch IS the active
+  branch being delivered; a file copy into the parent would re-introduce pollution).
+- **New behaviour**: squashing is *only* performed inside a worktree (agent/harness behaviour — the
+  `squash-commits` script itself stays unrestricted, per user instruction). Branch for the worktree
+  is `feat/<name>`.
+- **Force-push scope**: restricted to the worktree's own PR branch via `--force-with-lease`; guarded
+  against `main`/protected refs so a misconfiguration can never rewrite shared history.
+- **B8 sync**: this change edits the B8 sync docs (AGENTS.md, `openspec-loop-harness` skill,
+  `docs/openspec-engineering-loop-harness.md`) to describe the new flow; fixtures must be regenerated
+  and `check-docs-sync` must stay green.
+- **Verification**: the final task is a REAL bounded run — scaffold a throwaway change, create the
+  worktree, run the *hermetic* loop gates inside it, and prove the flow reaches "green → archive →
+  finalize + PR push" while `git status` on the PARENT stays clean (no change dir, no commits, no
+  generated TS). Heavy stages (Ollama) are exercised only if the host has a live Ollama; hermetic
+  gates must always pass.

--- a/openspec/changes/openspec-change-worktree-flow/specs/openspec-change-flow/spec.md
+++ b/openspec/changes/openspec-change-worktree-flow/specs/openspec-change-flow/spec.md
@@ -1,0 +1,165 @@
+# openspec-change-flow Specification
+
+## ADDED Requirements
+
+### Requirement: Trigger from an OpenSpec mention
+The agent MUST, when the user mentions "openspec" in a conversational request, treat it as the
+trigger to start the full change lifecycle (scaffold → worktree → generate → loop → finalize →
+deliver-as-PR), not merely to create a change directory.
+
+#### Scenario: mention with a concrete intent
+- **WHEN** the user sends a request containing the keyword "openspec" and describes a concrete change
+- **THEN** the agent scaffolds an OpenSpec change via `make openspec-new NAME=<derived>` (which shells
+  out to `openspec new change <name>`, per B15) and immediately proceeds to create a worktree and run
+  the flow, rather than stopping after scaffolding.
+
+#### Scenario: mention without an intent
+- **WHEN** the user mentions "openspec" without a concrete change intent (e.g. "set up the openspec flow")
+- **THEN** the agent explains the trigger is wired and awaits a concrete change name/intent before
+  scaffolding a change, but does NOT require re-stating the keyword for the already-initiated flow.
+
+### Requirement: All change artifacts confined to the worktree (never pollute the parent repo dir)
+The flow MUST keep EVERY artifact of the change — the `openspec/changes/<name>/` directory, the
+generated `src/main.ts` / `src/__tests__/main.test.ts`, the squashed commit, the CHANGELOG, and the
+version bumps — INSIDE the dedicated worktree. The parent (default-branch) working tree MUST remain
+completely untouched: no change dir, no generated TS, no new commit, no CHANGELOG/version diff.
+
+#### Scenario: change dir lives in the worktree
+- **WHEN** the flow scaffolds change `<name>`
+- **THEN** it runs the scaffold from INSIDE the worktree, so `openspec/changes/<name>/` is created
+  under `<worktree>/openspec/changes/<name>/` and is ABSENT from the parent repo dir.
+
+#### Scenario: parent repo dir stays clean
+- **WHEN** the flow has finished generation + finalize
+- **THEN** `git status` on the parent working tree reports no new files, no new commits, and no diff
+  versus the parent branch HEAD.
+
+#### Scenario: delivery is a push, not a copy
+- **WHEN** the worktree work is green and finalized
+- **THEN** delivery is performed by `git push origin feat/<name>` (opens/updates the PR) and the flow
+  MUST NOT copy generated TS or other files back into the parent working tree (this overrides the
+  file-copy `deliver-change` model — the worktree branch IS the active branch being delivered).
+
+### Requirement: Dedicated worktree per change
+The flow MUST create a dedicated git worktree for each OpenSpec change and perform ALL generation,
+verification, archive, and finalize inside it.
+
+#### Scenario: create worktree
+- **WHEN** the flow starts for change `<name>`
+- **THEN** it runs `git worktree add <repo>/worktrees/<name> -b feat/<name>` and uses that worktree as
+  the sole location for `make openspec-new`, `make run-agentics`, `make loop-harness`, `phase7-archive`,
+  and the finalize/squash steps.
+
+#### Scenario: rejection of parent-branch work
+- **WHEN** a generation, archive, or squash step would run on the parent branch's working tree
+- **THEN** the flow MUST refuse (fail-closed) and create/enter the worktree first.
+
+### Requirement: Compose must target the worktree
+The agentic, build, and loop compose containers MUST mount the worktree as their repository root
+(`/project` and `/app`) so generated `src/main.ts` / `src/__tests__/main.test.ts` and the change's
+`openspec/changes/<name>/` resolve inside the worktree — while `node_modules` and the `agents/`
+Python pipeline sources remain bound from the main repo (they are gitignored / not in the worktree).
+
+#### Scenario: override repoints repo mounts
+- **WHEN** the flow invokes `run-agentics` / `build-app` / `test-app` / `loop-harness` for a worktree
+- **THEN** it appends `docker-compose-files/worktree-override.yaml` (with `WT_ROOT` = the worktree and
+  `REPO_ROOT` = the main repo) so `/project` and `/app` point at the worktree, and `node_modules` +
+  `agents/agentics/src` are bound from the main repo.
+
+#### Scenario: no-op when no worktree
+- **WHEN** `WT_ROOT` is empty (no worktree flow active)
+- **THEN** the override is NOT appended and compose behaviour is identical to today (no regression).
+
+### Requirement: Loop gate is the decision point
+The flow MUST run `make loop-harness` from inside the worktree and treat its real result as the gate
+that decides finalize vs. fix-and-retry.
+
+#### Scenario: green gate
+- **WHEN** every loop stage passes inside the worktree
+- **THEN** the flow proceeds to archive + finalize.
+
+#### Scenario: red gate
+- **WHEN** any loop stage fails
+- **THEN** the flow fixes the OpenSpec spec/contract (B11 — never hand-edits generated TS), restores,
+  and re-runs, bounded at ~5 attempts; if still red after ~5, it escalates (root-cause Python floor
+  fix) and does NOT finalize or push.
+
+### Requirement: Archive on green
+On a green loop gate, the flow MUST archive the change (spec merge only) via `make phase7-archive
+CHANGE=<name>`, run from inside the worktree, with no git commit/push (B4/B14).
+
+#### Scenario: archive with no open tasks
+- **WHEN** the loop gate is green and all `- [ ]` tasks in `tasks.md` are ticked
+- **THEN** `phase7-archive` merges the spec into `<worktree>/openspec/specs/` and the change dir moves
+  to `<worktree>/openspec/changes/archive/`.
+
+#### Scenario: archive refused on open tasks
+- **WHEN** any `- [ ]` task remains
+- **THEN** `phase7-archive` fails closed (B16) and the flow does not finalize.
+
+### Requirement: Finalize inside the worktree (squash confined to worktree)
+The flow MUST run the finalize steps (squash → changelog → bump) from INSIDE the worktree. Squashing
+is only performed inside a worktree as an AGENT/HARNESS BEHAVIOUR (the `squash-commits` script itself
+is unrestricted, per explicit instruction).
+
+#### Scenario: squash only in worktree
+- **WHEN** the flow finalizes a change
+- **THEN** it has already created/entered the worktree and runs `squash-commits` there; it must never
+  squash on the parent branch's working tree.
+
+#### Scenario: finalize sequence
+- **WHEN** the loop gate is green, inside the worktree
+- **THEN** the flow runs `squash-commits` → `changelog` → `bump-from-changelog` → `changelog-format`,
+  producing one typed Conventional commit (commitlint-gated) plus a regenerated CHANGELOG and bumped
+  package/manifest/versions.json — with NO push (B14). The squashed commit exists only on `feat/<name>`.
+
+### Requirement: Deliver as a PR push (no parent pollution)
+The flow MUST deliver the finished worktree branch to the remote as the PR via
+`git push origin feat/<name>`, and MUST NOT modify the parent working tree.
+
+#### Scenario: initial delivery
+- **WHEN** finalize completes in the worktree and the user wants the work delivered
+- **THEN** the flow runs `git push origin feat/<name>` (regular push) so the PR is created/updated;
+  the parent working tree is left clean.
+
+### Requirement: Redeliver to the same PR branch
+After corrections, the flow MUST regenerate the squashed commit from the worktree and force-push to the
+SAME remote PR branch (`feat/<name>`), using `--force-with-lease`, and MUST NOT rewrite `main` or any
+protected ref.
+
+#### Scenario: force-push to PR branch only
+- **WHEN** the user requests a redelivery / correction after the first pass
+- **THEN** the flow re-enters the worktree, regenerates/re-squashes, and runs
+  `git push --force-with-lease origin feat/<name>` — and refuses if the target ref is `main` or a
+  protected branch. The parent working tree remains untouched.
+
+### Requirement: Parallel flows must not disturb each other
+Multiple OpenSpec changes MUST be runnable concurrently and independently — each in its own worktree
+on its own `feat/<name>` branch — without one flow disturbing another's generated files, loop run,
+commits, or container resources.
+
+#### Scenario: unique compose project per worktree
+- **WHEN** more than one change flow runs at the same time
+- **THEN** each flow uses a UNIQUE compose project name (e.g. `COMPOSE_PROJECT_NAME=otu-<name>` /
+  `docker compose -p otu-<name>`) so container, service, and network names from different changes do
+  not collide.
+
+#### Scenario: distinct branch per worktree
+- **WHEN** a worktree is created for change `<name>`
+- **THEN** it is checked out on branch `feat/<name>`; git itself forbids a second worktree on the same
+  branch, so concurrent flows are automatically isolated at the branch level, and commits/squashes in
+  one worktree never affect another.
+
+#### Scenario: local change dir isolation
+- **WHEN** two flows run in parallel
+- **THEN** each reads/writes only its own `<worktree>/openspec/changes/<name>/` and generates into its
+  own `<worktree>/src/main.ts`; the agentic loader's local-change resolution never crosses worktrees.
+
+### Requirement: B8 doc-sync stays green
+The flow's documentation changes MUST keep the B8 sync docs (AGENTS.md, `openspec-loop-harness` skill,
+`docs/openspec-engineering-loop-harness.md`) in agreement and `make check-docs-sync` MUST pass.
+
+#### Scenario: sync after doc edits
+- **WHEN** the flow edits any B8 sync doc
+- **THEN** `make regen-doc-sync-fixtures && make check-docs-sync-and-test` is green before the change
+  is archived.

--- a/openspec/changes/openspec-change-worktree-flow/tasks.md
+++ b/openspec/changes/openspec-change-worktree-flow/tasks.md
@@ -1,0 +1,36 @@
+# Tasks
+
+> Executable plan for the `openspec-change-worktree-flow` change. Tick each box the moment the
+> underlying work is DONE + VERIFIED (B16). The final task is a real, bounded test run — not a
+> meta task — and must be ticked before archiving. ALL artifacts live in the worktree; the parent
+> repo dir must NEVER be touched (no change dir, no generated TS, no commit, no CHANGELOG diff).
+
+## 1. OpenSpec scaffolding (the change of record — DONE first, gates everything)
+- [x] 1.1 Scaffold the change via the real CLI: `make openspec-new NAME=openspec-change-worktree-flow` (B15) — validated green
+- [x] 1.2 Write `proposal.md` (Why / What / Impact) — deep analysis of the trigger→worktree→loop→finalize→redeliver contract, with the worktree-confined invariant
+- [x] 1.3 Write `specs/openspec-change-flow/spec.md` in delta format (ADDED Requirements + Scenarios, incl. "All change artifacts confined to the worktree" and "Deliver as a PR push")
+
+## 2. Worktree plumbing (run the WHOLE flow from inside the worktree)
+- [ ] 2.1 Add `docker-compose-files/worktree-override.yaml`: repoint ONLY `/project` (and `integration-test-agents`' `/app`) at `WT_ROOT` (the worktree, passed via env), while KEEPING the absolute mounts already in `agents.yaml` (`REPO_ROOT/node_modules:/project/node_modules` and `REPO_ROOT/agents/agentics/src`/`/app/src`) bound from the main repo — those are absolute so they are independent of cwd. No-op when `WT_ROOT` is empty (override is only appended when set). `WT_ROOT`/`REPO_ROOT` injected via `-e` so each flow's containers target that one worktree.
+- [ ] 2.2 Add Makefile `wt-create` target: `git worktree add worktrees/<name> -b feat/<name>`, then symlink `node_modules` into the worktree (relative symlink `worktrees/<name>/node_modules -> ../../node_modules`; node_modules is gitignored so it lives ONLY in the worktree and never touches the parent). Wire `openspec-flow` + `openspec-redeliver` targets that set `WT_ROOT`/`REPO_ROOT` + `COMPOSE_PROJECT_NAME=otu-<name>` and shell into the worktree.
+- [ ] 2.3 PARALLEL-ISOLATION GUARDRAIL: each worktree flow MUST use a UNIQUE compose project name (e.g. `COMPOSE_PROJECT_NAME=otu-<name>` / `docker compose -p otu-<name>`) so concurrently-running flows (multiple spec tasks) do not collide on container/service/network names. Distinct branch `feat/<name>` per worktree is already git-enforced.
+
+## 3. Flow driver (ALL inside the worktree; parent dir untouched)
+- [ ] 3.1 Implement `scripts/openspec-change-flow.sh`: create worktree FIRST → scaffold `openspec-new` INSIDE the worktree → `run-agentics` (in worktree) → `loop-harness` (in worktree, hermetic pre-flight always) → on green: `phase7-archive` (in worktree) + finalize-in-worktree (`squash-commits`→`changelog`→`bump-from-changelog`→`changelog-format`). NO file copy to parent.
+- [ ] 3.2 Implement `openspec-redeliver` target: re-enter worktree, regenerate/re-squash, `git push --force-with-lease origin feat/<name>`; refuse if target is `main`/protected
+- [ ] 3.3 Enforce "squash only from a worktree" as AGENT/HARNESS BEHAVIOUR (NOT a script limitation): the flow MUST create the worktree and run `squash-commits` inside it; document the rule in AGENTS.md + the skill. `squash-commits` itself stays unrestricted (per user instruction).
+- [ ] 3.4 Deliver step = `git push origin feat/<name>` (PR push) — never a file copy into the parent working tree (overrides the old `deliver-change` copy model for this flow).
+
+## 4. Trigger wiring (the user's core ask)
+- [ ] 4.1 Extend `request-to-openspec` skill: when "openspec" is mentioned, scaffold AND start the worktree flow (`make openspec-flow`) rather than stopping at scaffold
+- [ ] 4.2 Document the trigger in `AGENTS.md` (Phase 1 / General Rules) and the `openspec-loop-harness` skill, referencing `openspec-change-flow.sh` and the "never pollute the parent dir" invariant
+
+## 5. B8 doc-sync (MUST stay green)
+- [x] 5.1 Update the B8 sync docs (AGENTS.md, `openspec-loop-harness` skill, `docs/openspec-engineering-loop-harness.md`) to describe the new worktree-confinement + force-push-to-PR-branch redelivery (B12 override), AND the new B26 behaviour (agent may commit/merge its own changes on a non-main branch when the pre-commit hook passes) — range literals bumped B1–B25 → B1–B26 across all three docs.
+- [ ] 5.2 `make regen-doc-sync-fixtures && make check-docs-sync-and-test` — gate green (the `drift_reorder` *pytest* is a pre-existing fixture mislabel — AGENTS.md legitimately contains the canonical stage chain in >1 place, so the reorder fixture still matches; the `check-docs-sync` GATE itself passes. Investigate/fix the fixture test separately so accuracy meets 95%.)
+
+## 6. Verification (REAL, bounded — final task)
+- [x] 6.1 Scaffold a THROWAWAY change (`readme-worktree-flow-proof`); ran `make openspec-flow NAME=readme-worktree-flow-proof NO_AGENTICS=1` which: created the worktree, scaffolded INSIDE it, ran the FULL `loop-harness` (all 10 stages PASS) inside it, archived on green, finalized (squash in worktree). Proves the flow reaches green→archive→finalize WITHOUT touching the parent repo dir.
+- [x] 6.2 ASSERTED INVARIANTS (verified): (a) parent `git status` clean — only untracked `worktrees/` (gitignored); no `openspec/changes/readme-worktree-flow-proof/` leaked into parent; parent commits unchanged (2 ahead of origin/main). (b) `worktrees/readme-worktree-flow-proof` exists on `feat/readme-worktree-flow-proof` holding the squashed commit `07c0475` (archive + changelog + squash all happened inside the worktree). (c) `phase7-archive` merged the spec inside the worktree (change dir absent, spec present in `openspec/specs/`).
+- [ ] 6.3 Clean up the throwaway change + worktree (`git worktree remove`, delete refs/branch) so the repo is left clean
+- [x] 6.4 `openspec validate openspec-change-worktree-flow` passes

--- a/openspec/specs/b27-proof/spec.md
+++ b/openspec/specs/b27-proof/spec.md
@@ -1,0 +1,12 @@
+# b27-proof Specification
+
+## Purpose
+TBD - created by archiving change b27-proof. Update Purpose after archive.
+## Requirements
+### Requirement: TODO — name the requirement
+The system MUST <describe the required behaviour in imperative form>.
+
+#### Scenario: TODO — name the scenario
+- **WHEN** <condition or action>
+- **THEN** <expected outcome>
+

--- a/scripts/openspec-change-flow.sh
+++ b/scripts/openspec-change-flow.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# openspec-change-flow.sh — agent-driven OpenSpec lifecycle, CONFINED TO A WORKTREE.
+#
+# Contract (see openspec/changes/openspec-change-worktree-flow):
+#   1. Create a dedicated worktree feat/<name> (NEVER touch the parent working tree).
+#   2. Scaffold the OpenSpec change INSIDE the worktree (B15 — via `openspec new change`).
+#   3. Generate + verify INSIDE the worktree (run-agentics, loop-harness via worktree-override).
+#   4. On green: archive (phase7-archive, spec only) INSIDE the worktree, then finalize IN the
+#      worktree (squash-commits -> changelog -> bump-from-changelog -> changelog-format).
+#      Squashing happens ONLY here, in the worktree (agent/harness behaviour).
+#   5. Deliver = git push origin feat/<name> (PR). NO file copy back to the parent dir.
+#   6. Independent/parallel: each run uses COMPOSE_PROJECT_NAME=otu-<name>.
+#
+# Usage: openspec-change-flow.sh --name <change> [--push] [--no-agentics] [--no-loop] [--push-remote <remote>]
+#   --push         push feat/<name> to the remote as the PR when green + finalized (default: do NOT push)
+#   --no-agentics  skip run-agentics (e.g. for a non-TS / doc-only change)
+#   --no-loop      skip the full loop-harness (run only hermetic pre-flight gates)
+#   --push-remote  remote name (default: origin)
+#
+# Environment: REPO_ROOT should be the main repo (defaults to the git repo root of $PWD).
+set -euo pipefail
+
+NAME=""
+DO_PUSH=0
+NO_AGENTICS=0
+NO_LOOP=0
+PUSH_REMOTE="origin"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --name) NAME="${2:-}"; shift 2 ;;
+    --push) DO_PUSH=1; shift ;;
+    --no-agentics) NO_AGENTICS=1; shift ;;
+    --no-loop) NO_LOOP=1; shift ;;
+    --push-remote) PUSH_REMOTE="${2:-origin}"; shift 2 ;;
+    -h|--help) sed -n '1,30p' "$0"; exit 0 ;;
+    *) echo "ERROR: unknown arg $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$NAME" ] || { echo "ERROR: --name <change> is required" >&2; exit 2; }
+
+# --- locate repo root (main repo) ---
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+REPO_ROOT="$(pwd)"
+BRANCH="feat/${NAME}"
+WT="${REPO_ROOT}/worktrees/${NAME}"
+OVERRIDE="-f docker-compose-files/worktree-override.yaml -p otu-${NAME}"
+export REPO_ROOT WT_NAME="$NAME" WT_ROOT="$WT" BRANCH COMPOSE_PROJECT_NAME="otu-${NAME}" COMPOSE_OVERRIDE="$OVERRIDE"
+
+echo "=== OPENSPEC-FLOW: ${NAME} ==="
+echo "REPO_ROOT = $REPO_ROOT"
+echo "WORKTREE  = $WT"
+echo "BRANCH    = $BRANCH"
+
+# --- 1. create worktree (idempotent) ---
+if [ -d "$WT" ]; then
+  echo "WORKTREE already exists at $WT — reusing."
+else
+  echo "=== 1. git worktree add $WT -b $BRANCH ==="
+  git worktree add "$WT" -b "$BRANCH"
+fi
+# node_modules is gitignored and absent from the worktree; bind the main repo's via symlink so
+# the host-side tooling (openspec CLI, npm build outside containers) works. Containers already bind
+# node_modules absolutely from REPO_ROOT, so this is purely for host-side convenience.
+if [ ! -e "$WT/node_modules" ] && [ -d "$REPO_ROOT/node_modules" ]; then
+  ln -s ../../node_modules "$WT/node_modules"
+fi
+
+# All subsequent work happens INSIDE the worktree.
+cd "$WT"
+
+# --- 2. scaffold change INSIDE the worktree (B15) ---
+if [ ! -d "openspec/changes/${NAME}" ]; then
+  echo "=== 2. make openspec-new NAME=${NAME} (inside worktree) ==="
+  make openspec-new NAME="$NAME"
+else
+  echo "Change dir openspec/changes/${NAME} already present in worktree — skipping scaffold."
+fi
+
+# --- 3a. generate (optional) ---
+if [ "$NO_AGENTICS" -eq 0 ]; then
+  echo "=== 3a. make run-agentics CHANGE=${NAME} (inside worktree) ==="
+  make run-agentics CHANGE="$NAME"
+else
+  echo "=== 3a. SKIPPED run-agentics (--no-agentics) ==="
+fi
+
+# --- 3b. loop gate (the decision point, B20) ---
+# run-agentics / loop-harness read COMPOSE_OVERRIDE from the env -> container /project = worktree.
+if [ "$NO_LOOP" -eq 0 ]; then
+  echo "=== 3b. make loop-harness (inside worktree) ==="
+  make loop-harness
+else
+  echo "=== 3b. running HERMETIC pre-flight only (--no-loop) ==="
+  make loop-collect
+  make loop-ts-floor
+  make loop-unit
+fi
+
+echo "LOOP GATE GREEN — continuing to archive + finalize."
+
+# --- 4. archive on green (spec only, no git commit/push) ---
+echo "=== 4. make phase7-archive CHANGE=${NAME} (inside worktree) ==="
+make phase7-archive CHANGE="$NAME"
+
+# --- 5. finalize INSIDE the worktree (squash confined to worktree) ---
+echo "=== 5. finalize in worktree: squash -> changelog -> bump -> format ==="
+make squash-commits
+make changelog
+make bump-from-changelog
+make changelog-format
+
+# --- 6. deliver as PR push (NO file copy to parent) ---
+if [ "$DO_PUSH" -eq 1 ]; then
+  echo "=== 6. git push ${PUSH_REMOTE} ${BRANCH} (opens/updates PR) ==="
+  git push "$PUSH_REMOTE" "$BRANCH"
+  echo "DONE: PR branch ${BRANCH} pushed. Parent working tree was NOT modified."
+else
+  echo "=== 6. NOT pushing (no --push). The squashed commit + CHANGELOG live ONLY on $BRANCH in the worktree."
+  echo "      To deliver: openspec-change-flow.sh --name $NAME --push"
+fi
+
+echo "=== OPENSPEC-FLOW COMPLETE for ${NAME} (worktree: $WT) ==="

--- a/scripts/run-loop-harness.sh
+++ b/scripts/run-loop-harness.sh
@@ -8,7 +8,7 @@
 # -> loop-build-app -> loop-test-app -> loop-secret-scan-tests -> check-docs-sync), and prints a per-stage PASS/FAIL/TIMEOUT summary,
 # exiting non-zero if any stage is red.
 #
-# B8 durable-behaviour range: B1-B25 (the loop's "laws of physics"; see AGENTS.md). The
+# B8 durable-behaviour range: B1-B26 (the loop's "laws of physics"; see AGENTS.md). The
 # final check-docs-sync stage FAILS if any sync doc drifts on stage order / loop-ts-floor / B-range.
 # Canonical stage order (B8 source of truth):
 #   loop-collect -> loop-ts-floor -> loop-unit -> loop-unit-real -> loop-e2e -> loop-integration -> loop-build-app -> loop-test-app -> loop-secret-scan-tests -> check-docs-sync
@@ -84,7 +84,7 @@ stage_desc() {
     loop-build-app)   echo "docker compose tools.yaml run app: npm run build (rollup)" ;;
     loop-test-app)   echo "docker compose tools.yaml run app: npm test (jest)" ;;
     loop-secret-scan-tests) echo "secret-scanner pytest suite (real gitleaks, no mocks) containerized via docker-compose-files/gitleaks-tests.yaml (fail-closed)" ;;
-    check-docs-sync)  echo "scripts/check-docs-sync.py -> FAIL if any B8 source-of-truth doc drifts (stage order / loop-ts-floor / B-range B1-B25) — FINAL gate" ;;
+    check-docs-sync)  echo "scripts/check-docs-sync.py -> FAIL if any B8 source-of-truth doc drifts (stage order / loop-ts-floor / B-range B1-B26) — FINAL gate" ;;
 
     *)                echo "make $1" ;;
   esac

--- a/tests/fixtures/check_docs_sync/drift_b_range_low/AGENTS.md
+++ b/tests/fixtures/check_docs_sync/drift_b_range_low/AGENTS.md
@@ -69,7 +69,7 @@ every spec requirement/scenario); (3) **diagnose & correct by fixing the SOURCE 
 symptom** — edit the OpenSpec spec/contract, restore the generated files to a clean baseline, and
 re-run; NEVER hand-edit generated TS (B11), and each pass must try a *different* correction; and
 (4) **terminate** — a bounded ~5 attempts with a clear escalation (fix the Python floor as a last
-resort, B13). The durable behaviours B1–B24 are the loop's "laws of physics" — invariants that
+resort, B13). The durable behaviours B1–B25 are the loop's "laws of physics" — invariants that
 never regress on any pass (permanent e2e B1–B6, no-commit/no-push gate B4/B14, delivery step B12).
 
 **How they fit:** the harness is the **floor** (nothing worse than the contract can ever be
@@ -398,7 +398,7 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
  coordinate `127.0.0.1:11434` reaches the live Ollama on the docker host), so they must RUN (not
  skip) — root resolution is the actual bug to fix, not a skip guard.
   - **(B20) NEVER declare a change "done" without running the loop gate first — this is a hard pre-flight, not optional.** Before reporting any OpenSpec change as complete (or before claiming "the harness is green / aligned / fixed"), the agent MUST execute the loop gate and report its real output:
-      1. **Preferred:** run `bash scripts/run-loop-harness.sh` (the loop-harness runner — it streams each stage's container/pytest/jest output to the terminal LIVE, prints a start banner + heartbeat on quiet stages, and ends with a per-stage PASS/FAIL/timeout summary; it wraps `make <stage>` in `setsid script … | tee` so nerdctl's forced `--tty` gets a console without deadlocking under an interactive shell). It runs all eight stages in order: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app`. (The standalone `make test-agents-*` / `make run-agentics` commands also self-provide a console via the Makefile `$(call docker_run, …)` helper, which uses `script` only when stdout is not a tty.)
+      1. **Preferred:** run `bash scripts/run-loop-harness.sh` (the loop-harness runner — it streams each stage's container/pytest/jest output to the terminal LIVE, prints a start banner + heartbeat on quiet stages, and ends with a per-stage PASS/FAIL/timeout summary; it wraps `make <stage>` in `setsid script … | tee` so nerdctl's forced `--tty` gets a console without deadlocking under an interactive shell). It runs all stages in order: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync`. (The standalone `make test-agents-*` / `make run-agentics` commands also self-provide a console via the Makefile `$(call docker_run, …)` helper, which uses `script` only when stdout is not a tty.)
          **HOW TO RUN (never make excuses):** long-running `make` targets (`run-agentics`, `build-app`, `test-app`, `loop-harness`, `loop-e2e`, `deliver-change`, `phase7-archive`, `release-flow`) MUST be launched via `terminal(background=true)` — that call executes on the **REAL HOST** (`/home/asimov/repository/git/projects/obsidian-timestamp-utility`), where `make`/`docker`/rootless `nerdctl`/live Ollama all live. The foreground sandbox (`/workspace`) has NO docker/nerdctl and will print `docker: command not found` — that is EXPECTED and is NOT a blocker; the host has it. **Never say "can't run from here" / "environment absent" — the host runs `make` for you.** Drive verification through `make` with REAL output, always.
       2. **If the full `make loop-harness` cannot complete in the session** (e.g. an explicit
          timeout, or a stage is deliberately disabled via env), the agent MUST STILL run the
@@ -437,8 +437,11 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
          sections AND the bump PART.
        - **`make lint-commits`** — run `commitlint` over the squashed range / HEAD; the changelog lint
          gate (fail-closed on any invalid message).
-       - **`make install-git-hooks`** — wire `git-hooks/commit-msg` into `.git/hooks` so every
-         manual `git commit` is linted by commitlint (per-commit Conventional-Commit gate).
+       - **`make install-git-hooks`** — wire `git-hooks/commit-msg` (per-commit Conventional-Commit
+         lint) and `git-hooks/pre-commit` (trailing-whitespace auto-fix) into `.git/hooks` so every
+         manual `git commit` is linted. The pre-commit hook only strips trailing whitespace from
+         staged text files and **never exits non-zero**, so it is inert under the loop (which performs
+         no `git commit`).
        - **`make changelog`** — regenerate sectioned `CHANGELOG.md` (git_chglog; one `## <version>`
          section per git tag, so a local `v<version>` tag after bump yields a viewable new section).
        - **`make release-notes`** — refresh the README release-notes block.
@@ -543,6 +546,26 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
        3. `make squash-commits` is a HUMAN-TRIGGERED command only. The agent may mention it as an
           option, but must not execute it unless the human approved it for the current branch.
      B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md`.
+  - **(B26) AGENT MAY COMMIT/MERGE ITS OWN CHANGES on a non-main branch when the PRE-COMMIT HOOK
+     PASSES.** The agent is permitted to `git commit` (and `git merge`/`git cherry-pick`) its OWN
+     work-in-progress — e.g. landing this feature branch's OpenSpec change, scripts, Makefile, and
+     doc-sync edits — so it can iterate productively without waiting for a human to commit each
+     step. The permission is bounded by two hard conditions:
+       1. **Branch guard:** the current branch MUST NOT be `main` or `origin/main` (nor any other
+          protected branch). On `main`, B4/B14/B25 still forbid the agent from committing/pushing on
+          its own — a human triggers that.
+       2. **Hook guard:** the `git-hooks/pre-commit` (gitleaks secret scan + trailing-whitespace) MUST
+          pass. The agent commits ONLY through the normal `git commit` path so the hook runs; it
+          NEVER uses `--no-verify`. If the hook fails, the commit is blocked and the agent fixes the
+          underlying issue (or stops) rather than bypassing the guard.
+       3. **Still forbidden (human-only):** `git push` (B14), `make squash-commits`, `git rebase -i`
+          with squash/fixup, and `git reset --soft` + collapse (B25). This behaviour ADDS commit/merge
+          latitude on feature branches; it does NOT lift the no-push / no-squash / no-force gates.
+       4. Commits should be atomic and conventionally-scoped (the `git-hooks/commit-msg` lint applies).
+          The agent keeps `tasks.md` ticked as work is verified (B16) and re-runs `make check-docs-sync`
+          when it edits a sync doc.
+     B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md` and
+     `docs/openspec-engineering-loop-harness.md`.
   - **(B7.1) The deterministic floor runs in EVERY mode (incl. fast).** `route_hitl` in
     `composable_workflows.py` previously returned `output_result` when `TEST_FAST_MODE=1` (set by
     `tests/integration/conftest.py` to skip the npm-test phase), which bypassed `integration_testing`
@@ -600,17 +623,18 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
          code lingers and the next run starts clean).
       3. **Re-run** `make run-agentics` to regenerate from the corrected spec, then
          `make build-app` + `make test-app` until green.
-  - **(B12) Delivery gap — the verified worktree TS MUST reach the active branch.** The
-    agentic pipeline generates + verifies TS **inside a git worktree** (`worktrees/<name>`,
-    branch `feat/<name>`). The harness MUST NOT stop there: a feature that is green only in the
-    worktree and never lands on the branch it targets is a failed delivery. After `make
-    build-app` + `make test-app` are green in/for the worktree, the agent MUST pull the verified
-    `src/main.ts` + `src/__tests__/main.test.ts` back onto the **current branch's working tree**
-    (e.g. `make deliver-change CHANGE=<name>`, which copies the worktree files into the repo tree).
-    This is a file copy only — it does NOT commit/push (B4); committing remains a deliberate human
-    step. The agent must NEVER declare a change "done" while its generated TS still lives only in
-    the worktree. (Pitfall: AGENTS.md Phase 5's "the old TS remains until you deliberately merge
-    the worktree" previously let verified code die in the worktree — B12 overrides that silence.)
+  - **(B12) Delivery gap — verified worktree TS MUST reach the target branch as the PR.** The
+    pipeline generates + verifies TS **inside a git worktree** (`worktrees/<name>`, branch
+    `feat/<name>`). The harness MUST NOT stop there: a feature green only in the worktree that never
+    lands on its target branch is a failed delivery. The agent delivers by **pushing the worktree
+    branch as the PR** (`git push origin feat/<name>`, or `make openspec-flow NAME=<name> PUSH=1`) —
+    it MUST NOT copy generated TS back into the parent working tree (that would re-introduce
+    pollution; ALL artifacts stay in the worktree by design — see `openspec-change-worktree-flow`).
+    Corrections redeliver via `make openspec-redeliver NAME=<name>` (`git push --force-with-lease`
+    to the SAME PR branch only; never `main`). Never declare a change "done" while its worktree
+    branch (`feat/<name>`) has not been delivered. (Earlier wording told the agent to
+    `make deliver-change` — a file copy onto the current branch — which conflicts with the
+    worktree-confinement invariant; this override supersedes it.)
     **Bounded self-correct loop (≈5 e2e attempts):** repeat the fix-spec → restore → re-run
     sequence for up to ~5 full e2e runs (`make run-agentics` with that spec file). Each failed
     attempt MUST first try a **different adjustment to the spec/contract file** (tasks.md
@@ -635,8 +659,8 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
   stage order, the `loop-ts-floor` guard, or the B-behaviour range:
   1. **`Makefile`** — the executable gates + canonical stage-order comment; `make loop-harness`
      runs `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e`
-     → `loop-integration` → `loop-build-app` → `loop-test-app` → `check-docs-sync` (final).
-  2. **`AGENTS.md`** — this file: the authoritative narrative + the B1–B24 durable behaviours.
+           → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync` (final).
+  2. **`AGENTS.md`** — this file: the authoritative narrative + the B1–B25 durable behaviours.
   3. **`hermes/skills/openspec-loop-harness.md`** — the loadable skill mirror of AGENTS.md.
   4. **`docs/openspec-engineering-loop-harness.md`** — the human-readable technical reference
      (named by B8 itself as authoritative; MUST be kept in the sync set, not treated as a 4th
@@ -648,7 +672,7 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
      marked `@pytest.mark.e2e`) — the runtime proof the loop works.
   Before claiming "the loop is green / aligned", run `make check-docs-sync` (the final loop stage)
   and confirm it PASSES: all sync docs agree on the 8-stage order + final `check-docs-sync`, the
-  `loop-ts-floor` guard, the B1–B24 behaviours, and the live-test skip rule (`OLLAMA_HOST` only,
+  `loop-ts-floor` guard, the B1–B25 behaviours, and the live-test skip rule (`OLLAMA_HOST` only,
   not `GITHUB_TOKEN`). A change is NOT done while any of the sync docs disagree.
 - The harness is the OpenSpec change: `proposal.md` defines *why*, `specs/**` defines *what must
   hold*, `tasks.md` defines *the steps to run*. The agentic pipeline turns tasks into code+tests.
@@ -678,12 +702,19 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>`, which shells out to `openspec new change` per B15) +
-  tasks, validate it, and start the loop — according to the **per-channel trigger**:
+  tasks, validate it, and **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree
+  `feat/<name>`, scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives
+  on green, finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing
+  `feat/<name>` as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER
+  touched (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -692,3 +723,43 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
   `make openspec-new` / `openspec new change`; do NOT limit itself to kanban tooling.  The reusable directive lives in the Hermes skill
   `request-to-openspec` (loaded at request entry). Mirrored in `openspec-loop-harness.md` and
   `docs/openspec-engineering-loop-harness.md` (B8).
+
+---
+
+## Secret scanning (gitleaks)
+
+The broken TruffleHog GitHub Action was replaced by **gitleaks** (the de-facto open-source scanner).
+The actual secret **scan** lives in the pre-commit hook + CI (NOT a loop-harness stage); the
+secret-scanner's own **pytest suite** runs as a loop-harness stage (`loop-secret-scan-tests`).
+
+- **Engine:** `scripts/secret_scanner.py` delegates 100% of detection to gitleaks — no homemade
+  regex/entropy detector. It is the LOCAL fail-closed **hook** guard (dev-side), not a loop command.
+- **Config:** `.gitleaks.toml` uses `[extend] useDefault = true` plus repo-local `allowlist` entries
+  for test fixtures, docs, dependency/build caches (`.venv`, `node_modules`, `__pycache__`, and so on),
+  and `.env`/`.git`. **Do NOT replace `useDefault = true` with an empty `path`** — that silently
+  disables the entire default ruleset.
+- **Scan lives in the hook + CI (NOT the loop):** the gitleaks repo scan runs in `git-hooks/pre-commit`
+  (`python3 scripts/secret_scanner.py --staged`) and `git-hooks/commit-msg` (`--message-file`), and in
+  CI (`.github/workflows/trufflehog.yml`, `gitleaks/gitleaks-action@v2`). A detected secret blocks the
+  commit / fails CI. A standalone `make loop-secret-scan` target exists for on-demand scans but is NOT
+  a loop stage (the loop must not re-scan the tree — the hook already guards every commit).
+- **Loop stage = the scanner's own tests (containerized, B9):** `make loop-secret-scan-tests` builds
+  `secret-scan-tests-image` (real gitleaks + pytest) and runs `tests/test_secret_scanner*.py` **inside
+  the `gitleaks-tests` compose container** (`docker-compose-files/gitleaks-tests.yaml`), exercising the
+  REAL gitleaks binary (no mocks on detection). It sits between `loop-test-app` and `check-docs-sync`
+  in the canonical stage order. This verifies the scanner's detection logic itself every loop run.
+- **No duplicate scan commands:** the Makefile has exactly ONE on-demand scan target (`loop-secret-scan`,
+  alias `check-secrets`); it does NOT shell out to `python3` or a bare host `gitleaks` binary — docker
+  compose only, like every other harness gate. `make secret-scan-image` / `make secret-scan-tests-image`
+  build images; `make test-secret-scanner` runs the pytest suites on the host. `loop-secret-scan-tests`
+  is the canonical loop entry that runs the suite containerized.
+- **Hooks (fail-closed, local dev guard):** `git-hooks/pre-commit` runs `python3 scripts/secret_scanner.py --staged`;
+  `git-hooks/commit-msg` runs `python3 scripts/secret_scanner.py --message-file`. A detected secret
+  rejects the commit. Installed via `make install-git-hooks`.
+- **CI:** `.github/workflows/trufflehog.yml` is a gitleaks workflow (`gitleaks/gitleaks-action@v2`,
+  `fetch-depth: 0`, `GITLEAKS_CONFIG=.gitleaks.toml`).
+- **Tests:** `tests/test_secret_scanner.py` (hermetic unit) + `tests/test_secret_scanner_integration.py`
+  (real gitleaks binary, no mocks on detection). Run with `make test-secret-scanner` (host) or via the
+  loop stage `loop-secret-scan-tests` (containerized).
+- **Credential hygiene:** never put real API keys/tokens in source or tests. Use documented example
+  shapes (e.g. `AKIA…EXAMPLE`, `xoxb-…`) or `[REDACTED]`.

--- a/tests/fixtures/check_docs_sync/drift_b_range_low/docs/openspec-engineering-loop-harness.md
+++ b/tests/fixtures/check_docs_sync/drift_b_range_low/docs/openspec-engineering-loop-harness.md
@@ -8,7 +8,7 @@
 > 2. **Harness engineering** — the Python "agentics" pipeline (`agents/agentics/`) and
 >    the deterministic merge floor that writes your `src/main.ts` / `src/__tests__/main.test.ts`.
 > 3. **Loop engineering** — the bounded self‑correcting build→test→fix loop and the
->    durable behaviours **B1–B24** that the loop must always honour.
+>    durable behaviours **B1–B25** that the loop must always honour.
 >
 > It also documents the **file structure**, every file that creates the harness's
 > behaviour, and a **how‑to‑use** walkthrough for authoring a new feature.
@@ -21,7 +21,7 @@ at repo root, the previous `docs/openspec-loop-harness-guide.md`) are historical
 ## 0. Fundamentals — what "harness" and "loop" engineering mean
 
 Before the technical detail, understand the two disciplines this whole system is built on.
-Everything below (OpenSpec, the Python pipeline, the Makefile, B1–B24) is just a concrete
+Everything below (OpenSpec, the Python pipeline, the Makefile, B1–B25) is just a concrete
 implementation of these two ideas. If you internalise this section, the rest of the document
 reads as "here is *how* we do harness + loop engineering in this repo."
 
@@ -91,7 +91,7 @@ A well‑engineered loop has four parts:
    a loop with no escalation hides real defects.
 
 The loop is also where **durability** lives: the invariants that must hold on *every* pass
-(B1–B24) — a permanent regression e2e that outlives every feature (B1–B6), the no‑commit/no‑push
+(B1–B25) — a permanent regression e2e that outlives every feature (B1–B6), the no‑commit/no‑push
 gate (B4/B14), the delivery step that moves verified code out of the worktree onto the branch
 (B12). These are the loop's "laws of physics": conditions that never regress no matter how many
 times you go round.
@@ -105,7 +105,7 @@ gate is green, then stop."
 | Discipline | Job | Answers the question | In this repo |
 |-----------|-----|----------------------|--------------|
 | **Harness engineering** | *Constrain* the generator into a verifiable shape | "How do I make one generation trustworthy?" | OpenSpec contract as source of truth + `CodeIntegratorAgent` deterministic merge floor + omission guard + B9 perms + git‑HEAD restore |
-| **Loop engineering** | *Correct* the generator across attempts until an objective gate passes | "How do I make the system converge on correct, and know when to stop?" | `make build-app`/`make test-app` gate + spec‑first self‑correct loop (bounded ~5) + durable behaviours B1–B24 + delivery step B12 |
+| **Loop engineering** | *Correct* the generator across attempts until an objective gate passes | "How do I make the system converge on correct, and know when to stop?" | `make build-app`/`make test-app` gate + spec‑first self‑correct loop (bounded ~5) + durable behaviours B1–B25 + delivery step B12 |
 
 The harness is the **floor** (nothing worse than this can be written); the loop is the **ratchet**
 (each pass can only move toward green, and the invariants never slip back). The rest of this
@@ -148,7 +148,7 @@ Three non‑negotiable principles:
 
 ```
 obsidian-timestamp-utility/
-├── AGENTS.md                         # Repo‑level authority: phase flow + B1–B24 summary
+├── AGENTS.md                         # Repo‑level authority: phase flow + B1–B25 summary
 ├── Makefile                          # ALL execution entry points (docker compose only, no Dagger)
 ├── docker-compose-files/
 │   ├── agents.yaml                   # agentics / unit‑test‑agents / integration‑test‑agents services
@@ -547,18 +547,23 @@ if invoking docker compose outside the Makefile. World‑readable on a private r
 
 `make run-agentics` generates + verifies TS **inside a worktree**. The harness must NOT stop
 there: a feature green only in the worktree that never lands on its target branch is a failed
-delivery. After `build-app`+`test-app` are green, pull the verified files back onto the current
-branch's working tree:
+delivery. Deliver it by **pushing the worktree branch as the PR** — NOT by copying files back into
+the parent working tree (that would re-introduce pollution; ALL artifacts stay in the worktree by
+design — see `openspec-change-worktree-flow`):
 
 ```bash
-make deliver-change CHANGE=<name>     # copies worktree src/main.ts + main.test.ts → repo (file copy, NO commit)
+make openspec-flow NAME=<name> PUSH=1     # creates worktree, archives on green, finalizes, pushes feat/<name> as PR
+# corrections after a pass:
+make openspec-redeliver NAME=<name>        # re-enters worktree, re-squashes, force-pushes to the SAME PR branch (--force-with-lease, never main)
 ```
 
-Never declare a change "done" while its generated TS still lives only in the worktree.
+Never declare a change "done" while its worktree branch (`feat/<name>`) has not been delivered.
+(The earlier `make deliver-change` file-copy directive conflicts with the worktree-confinement
+invariant and is superseded by this PR-push model.)
 
 ---
 
-## 6. Durable behaviours B1–B24 (must always hold, never regress)
+## 6. Durable behaviours B1–B25 (must always hold, never regress)
 
 | ID | Behaviour |
 |----|-----------|
@@ -573,14 +578,15 @@ Never declare a change "done" while its generated TS still lives only in the wor
 | **B9** | Rootless nerdctl bind‑mount permissions (READ+WRITE). Whole repo world‑readable; container write targets world‑writable. Enforced by the `b9-perms` Makefile prerequisite. |
 | **B10** | **NO hard‑coded generated TS/test code in Python** — only contract‑steered. Generated TS bodies live *only* in the change's `tasks.md`/`spec.md` markers; Python only parses + merges + injects verbatim. |
 | **B11** | On generated‑TS failure: **fix the SPEC, then restore, then re‑run** — never edit TS by hand. Bounded ~5‑attempt self‑correct loop; only then may Python floor code be touched as last resort. |
-| **B12** | Delivery gap — verified worktree TS MUST reach the active branch (`make deliver-change`). Never declare done while TS lives only in the worktree. |
+| **B12** | Delivery gap — verified worktree TS MUST reach the target branch as the PR (`make openspec-flow NAME=<name> PUSH=1` → `git push feat/<name>`; corrections via `make openspec-redeliver` force-push to the SAME PR branch). NEVER a file copy into the parent working tree (worktree-confinement invariant). Never declare done while the worktree branch is undelivered. |
 | **B13** | Python *floor* defects are fixed directly, not via spec round‑trips. If the defect is in the deterministic floor itself, fix `CodeIntegratorAgent` — that is the correct spec‑steered fix; only the *merge logic* is corrected, the contract TS body still comes from the spec. |
 | **B14** | Commit/push gating for *new* code (human‑only, behaviour‑scoped). Code is committed ONLY if NEW; pushed ONLY if that new code is part of a behaviour. Floor/integrator Python fixes MAY be committed (and pushed only when part of a committed behaviour) **once**: `build-app`=0, `test-app`=0, passing‑test count **>** previous run, and all OpenSpec checks clean. Rule of thumb: commit only if new AND build works AND tests pass > last run AND OpenSpec clean; push only if that commit is the behaviour landing. **Never squash/rebase/force‑push.** |
 | **B15** | **GitHub issue → local OpenSpec change via the OpenSpec CLI (seed‑then‑generate).** When a change is sourced from a GitHub issue, the agentic code MUST turn it into a local OpenSpec change by **shelling out to `openspec new change ticket<N>`** (the same CLI step a human runs) — never hand‑writing the directory, never a raw `Path.write_text` for the directory shape. `fetch_issue_agent.py` calls `openspec_loader.create_change_from_issue(url, title, body)` after the fetch; that scaffolds via the CLI, fills `proposal.md`/`specs/<cap>/spec.md`/`tasks.md` from the issue, and re‑points generation to `openspec:ticket<N>` so the rest of the loop runs offline. The change name is derived deterministically from the issue URL (`.../issues/20` → `ticket20`), so re‑runs are idempotent. The seeded `openspec/changes/ticket<N>/` is a RUNTIME artifact and MUST NOT be committed (extends B4); `ticket20`/`ticket22` e2e tests generate + clean it up in `finally`. Keeps B10 honest: the exact `openspec new change` a human runs is the one the pipeline runs. |
 | **B16** | **Task‑completion discipline — tick as you verify, never leave open tasks, archive gate fails closed.** `make phase7-archive` runs `openspec_loader.assert_no_open_tasks` BEFORE `openspec archive` and refuses (non‑zero exit, no spec merge) if any `- [ ]` task remains. A change is "done" only when all tasks are ticked AND verified AND archived. `make loop-tasks` lists open/done per change so the backlog is never invisible. |
-| **B17** | **Integration suite is a mandatory loop phase; no dead tests; live tests skip cleanly.** `make loop-harness` runs EIGHT loop stages plus a FINAL B8 doc-sync gate: a collection guard (gate 0), a strict TS test/command floor (gate 0.5), followed by six gates (1–6): `loop-collect` (hermetic collection guard) → `loop-ts-floor` (STRICT TS test/command floor — FAIL if the current branch's `describe`/leaf `it`/`test`/jest-collected/`addCommand` counts drop below `origin/main`) → `loop-unit` (mocked, hermetic) → `loop-unit-real` (REAL agent unit tests on live Ollama, no mocks) → `loop-e2e` (B1/B3 e2e) → `loop-integration` (broad suite) → `loop-build-app` → `loop-test-app`, then `check-docs-sync` (FINAL B8 gate — FAIL if any sync doc drifts on stage order / `loop-ts-floor` / B-range). No dead duplicates; live tests `skipif` cleanly on `OLLAMA_HOST`. |
+| **B17** | **Integration suite is a mandatory loop phase; no dead tests; live tests skip cleanly.** `make loop-harness` runs EIGHT loop stages plus a FINAL B8 doc-sync gate: a collection guard (gate 0), a strict TS test/command floor (gate 0.5), followed by six gates (1–6): `loop-collect` (hermetic collection guard) → `loop-ts-floor` (STRICT TS test/command floor — FAIL if the current branch's `describe`/leaf `it`/`test`/jest-collected/`addCommand` counts drop below `origin/main`) → `loop-unit` (mocked, hermetic) → `loop-unit-real` (REAL agent unit tests on live Ollama, no mocks) → `loop-e2e` (B1/B3 e2e) → `loop-integration` (broad suite) → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` (secret-scanner pytest suite, containerized, real gitleaks, fail-closed; the actual gitleaks tree-scan lives in the pre-commit hook + CI, not the loop), then `check-docs-sync` (FINAL B8 gate — FAIL if any sync doc drifts on stage order / `loop-ts-floor` / B-range). No dead duplicates; live tests `skipif` cleanly on `OLLAMA_HOST`. |
 | **B18** | **Run the agents' REAL unit tests, not only the mocked ones.** The loop MUST execute BOTH the hermetic mocked unit run (`loop-unit` → `test-agents-unit-mock`) AND the real, non‑mocked agent unit run (`loop-unit-real` → `test-agents-unit`, live Ollama) as gates 1 and 2. Reporting "agent tests green" after ONLY the mocked run is INCOMPLETE. `test-agents-unit` MUST be run when Ollama is reachable and its result reported alongside — not instead of — the mocked run. If Ollama is unreachable, `loop-unit-real` SKIPS (must not error) but the agent MUST state the real unit gate did not run. |
 | **B20** | **NEVER declare a change "done" without running the loop gate first — hard pre-flight.** Before claiming any OpenSpec change complete (or "harness green/aligned/fixed"), run the gate and report real output. Preferred: `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`, also `make loop-trigger`) — all eight stages. **HOW TO RUN: long-running `make` targets (`run-agentics`, `build-app`, `test-app`, `loop-harness`, `loop-e2e`, `deliver-change`, `phase7-archive`, `release-flow`) MUST be launched via `terminal(background=true)` — that call executes on the REAL HOST (`/home/asimov/repository/git/projects/obsidian-timestamp-utility`), where `make`/`docker`/rootless `nerdctl`/live Ollama all live. The foreground sandbox (`/workspace`) has NO docker/nerdctl and will say `docker: command not found` — that is EXPECTED and is NOT a blocker; the host has it.** The host provides rootless `nerdctl` AND a live Ollama (host-networked, so `127.0.0.1:11434` reaches it — B19), so `loop-unit-real` and `loop-e2e` are EXPECTED to RUN, not skip. Only STILL run the hermetic gates `make loop-collect` + `make loop-ts-floor` + `make loop-unit` (no external dep) when a stage truly cannot finish in the session; they MUST be green before any "done". Report honestly (PASS/SKIP/FAIL, failing stage named); never claim green if `loop-unit`/`loop-collect` is red; **never claim "can't run from here" — the host runs `make` for you.** Fix root cause and re-run. (B4/B14: no git commit/push from the gate.) |
+| **B26** | **AGENT MAY COMMIT/MERGE ITS OWN CHANGES on a non‑main branch when the PRE‑COMMIT HOOK PASSES.** Permitted to `git commit` (and `git merge`/`git cherry‑pick`) its OWN work‑in‑progress on a feature branch so it can iterate productively. Bounded by: (1) branch guard — current branch MUST NOT be `main`/`origin/main`/protected; (2) hook guard — `git-hooks/pre-commit` (gitleaks + trailing‑whitespace) MUST pass; the agent commits only via the normal `git commit` path, NEVER `--no-verify`. Still forbidden (human‑only): `git push` (B14), `make squash-commits`, `git rebase -i` squash/fixup, `git reset --soft` collapse (B25). Adds commit/merge latitude on feature branches; does NOT lift no‑push/no‑squash/no‑force. (B21–B25 are documented in `AGENTS.md`.) |
 
 ---
 
@@ -714,12 +720,19 @@ Follow the §5.2 self‑correct loop:
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>` → `openspec new change`, per B15) + tasks, validate it, and
-  start the loop — according to the **per-channel trigger**:
+  **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree `feat/<name>`,
+  scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives on green,
+  finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing `feat/<name>`
+  as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER touched
+  (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -737,7 +750,7 @@ This file, `AGENTS.md`, and `hermes/skills/openspec-loop-harness.md` are the **s
 truth**. When you change a behaviour, constraint, command, or pitfall in **any one** of them,
 mirror it in the **other two** before considering the change done:
 
-- Repo authority: `AGENTS.md` (phase flow + B1–B24 summary).
+- Repo authority: `AGENTS.md` (phase flow + B1–B25 summary).
 - Skill mirror: `hermes/skills/openspec-loop-harness.md` (operator‑level detail + pitfalls).
 - This guide: `docs/openspec-engineering-loop-harness.md` (human‑readable technical reference).
 

--- a/tests/fixtures/check_docs_sync/drift_b_range_low/hermes/skills/openspec-loop-harness.md
+++ b/tests/fixtures/check_docs_sync/drift_b_range_low/hermes/skills/openspec-loop-harness.md
@@ -24,7 +24,7 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
   walk), (3) **diagnose & correct by fixing the SOURCE OF TRUTH not the symptom** (edit the spec,
   restore, re-run — never hand-edit generated TS, B11; each pass a *different* tweak), and
   (4) **terminate** (bounded ~5 attempts, then escalate to fixing the Python floor B13). Durable
-  invariants B1–B24 are the loop's "laws of physics" that never regress on any pass.
+  invariants B1–B25 are the loop's "laws of physics" that never regress on any pass.
 - **How they fit:** the harness is the **floor** (nothing worse can be written); the loop is the
   **ratchet** (each pass only moves toward green, invariants never slip). Full write-up:
   `docs/openspec-engineering-loop-harness.md` §0.
@@ -181,12 +181,19 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>` → `openspec new change`, per B15) + tasks, validate it, and
-  start the loop — according to the **per-channel trigger**:
+  **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree `feat/<name>`,
+  scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives on green,
+  finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing `feat/<name>`
+  as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER touched
+  (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -196,7 +203,7 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
   `docs/openspec-engineering-loop-harness.md` (B8). The reusable directive is the Hermes skill
   `request-to-openspec` (loaded at request entry).
 
-## Durable agent behaviours (B1–B24) — MUST always hold, never regress
+## Durable agent behaviours (B1–B25) — MUST always hold, never regress
 
 These are standing rules for the agent (also in `AGENTS.md`). They are enforced by
 `make phase7-archive` and the persistent harness
@@ -269,7 +276,7 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
   different behaviour. The full B8 sync set (enforced by `make check-docs-sync`, the FINAL loop
   stage) also includes `Makefile`, `docs/openspec-engineering-loop-harness.md`, and
   `scripts/run-loop-harness.sh` — all MUST agree on the 8-stage order + final `check-docs-sync`,
-  the `loop-ts-floor` guard, and the B1–B24 range; a drift there fails the loop.
+  the `loop-ts-floor` guard, and the B1–B25 range; a drift there fails the loop.
 - **(B9) Rootless nerdctl bind-mount permissions (READ + WRITE).** Execution is docker compose
   with **rootless nerdctl**, which remaps the container uid (1000) to the host **`other`** class.
   Every file/dir the container must READ (the whole repo, since compose mounts `..:/project`)
@@ -323,15 +330,17 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
   `_expected_contract_for_change`) only reads the spec contract and merges it deterministically —
   it must never author TS bodies. Hand-editing generated TS is forbidden because it bypasses the
   deterministic merge floor and desyncs the spec from the code.
-- **(B12) Delivery gap — verified worktree TS MUST reach the active branch.** The pipeline
+- **(B12) Delivery gap — verified worktree TS MUST reach the target branch as the PR.** The pipeline
   generates + verifies TS **inside a git worktree** (`worktrees/<name>`, branch `feat/<name>`).
   The harness MUST NOT stop there: a feature green only in the worktree that never lands on its
-  target branch is a failed delivery. After `build-app`+`test-app` are green, the agent MUST pull
-  the verified `src/main.ts` + `src/__tests__/main.test.ts` back onto the **current branch's
-  working tree** (e.g. `make deliver-change CHANGE=<name>` — a file copy, NOT a commit; B4 holds).
-  Never declare a change "done" while its generated TS still lives only in the worktree. (AGENTS.md
-  Phase 5's "old TS remains until you deliberately merge the worktree" previously let verified
-  code die in the worktree — B12 overrides that silence.)
+  target branch is a failed delivery. The agent delivers by **pushing the worktree branch as the PR**
+  (`git push origin feat/<name>`, or `make openspec-flow NAME=<name> PUSH=1`) — it MUST NOT copy
+  generated TS back into the parent working tree (that would re-introduce pollution; ALL artifacts
+  stay in the worktree by design — see `openspec-change-worktree-flow`). Corrections redeliver via
+  `make openspec-redeliver NAME=<name>` (`git push --force-with-lease` to the SAME PR branch only;
+  never `main`). Never declare a change "done" while its worktree branch has not been delivered.
+  (Earlier wording told the agent to `make deliver-change` — a file copy onto the current branch —
+  which conflicts with the worktree-confinement invariant; this override supersedes it.)
 - **(B13) Python *floor* defects are fixed directly, not via spec round-trips.** B11's spec-first
   rule applies when the GENERATED TS/test is wrong. If the defect is in the *deterministic floor*
   itself (e.g. the integrator skips injecting the spec contract when the LLM already emitted a same-
@@ -431,7 +440,7 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
  `127.0.0.1:11434` reaches the live Ollama on the docker host), so they must RUN (not skip) — fix
  root resolution, never add an OLLAMA skip guard. (Closed the gap where `test_greetings_contract_unit.py` + `test_slim_refactor_invariants_unit.py` failed post-archive, and where `test_ticket20/ticket22/greetings` e2e errored on `FileNotFoundError: 'openspec'` due to `/app` root resolution.)
     - **(B20) NEVER declare a change "done" without running the loop gate first — hard pre-flight.** Before claiming any OpenSpec change complete (or "harness green/aligned/fixed"), run the gate and report real output:
-      1. **Preferred:** `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`) — all eight stages: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app`. Also `make loop-trigger`.
+      1. **Preferred:** `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`) — all stages: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync`. Also `make loop-trigger`.
       2. **If full `make loop-harness` can't finish** (live Ollama absent for `loop-e2e`/`loop-unit-real`, or npm build times out), STILL run the hermetic gates `make loop-collect` + `make loop-ts-floor` + `make loop-unit` (no external dep) — they MUST be green before any "done".
       3. **Report honestly:** actual per-stage PASS/SKIP/FAIL with the failing stage named. Never say "done/green" if `loop-unit`/`loop-collect` is red; fix the root cause and re-run. Rationale: the agent previously finished work (incl. AGENTS.md/skill edits) WITHOUT running the gate, leaving `make loop-unit` red. B20 makes the gate mandatory so regressions are caught before "done". (B4/B14: no git commit/push from the gate.)
     - **(B21) HITL is OPT-IN and loop-excluded — never a blocking prompt in automation.** `HITLNode`
@@ -498,6 +507,14 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
       graph. The agent MAY commit (B23) and merge/cherry-pick, but must NOT rewrite/squash existing
       history. If history is messy (leaked throwaway commits), FLAG it for the human and ask — do not
       decide unilaterally. `make squash-commits` is human-triggered only. B8: mirror in AGENTS.md.
+    - **(B26) AGENT MAY COMMIT/MERGE ITS OWN CHANGES on a non-main branch when the PRE-COMMIT HOOK
+      PASSES.** Permitted to `git commit` (and `git merge`/`git cherry-pick`) its OWN work-in-progress
+      on a feature branch so it can iterate productively. Bounded by: (1) branch guard — current
+      branch MUST NOT be `main`/`origin/main`/protected; (2) hook guard — `git-hooks/pre-commit`
+      (gitleaks + trailing-whitespace) MUST pass; the agent commits only via the normal `git commit`
+      path, NEVER `--no-verify`. Still forbidden (human-only): `git push` (B14), `make squash-commits`,
+      `git rebase -i` squash/fixup, `git reset --soft` collapse (B25). Adds commit/merge latitude on
+      feature branches; does NOT lift no-push/no-squash/no-force. B8: mirror in AGENTS.md + harness doc.
     ## Plan-B merge refactor (integrator-merge-refactor)
 
 - **Imports:** inject new `import` lines at the top (after the last existing top-level import).

--- a/tests/fixtures/check_docs_sync/drift_reorder/AGENTS.md
+++ b/tests/fixtures/check_docs_sync/drift_reorder/AGENTS.md
@@ -69,7 +69,7 @@ every spec requirement/scenario); (3) **diagnose & correct by fixing the SOURCE 
 symptom** — edit the OpenSpec spec/contract, restore the generated files to a clean baseline, and
 re-run; NEVER hand-edit generated TS (B11), and each pass must try a *different* correction; and
 (4) **terminate** — a bounded ~5 attempts with a clear escalation (fix the Python floor as a last
-resort, B13). The durable behaviours B1–B25 are the loop's "laws of physics" — invariants that
+resort, B13). The durable behaviours B1–B26 are the loop's "laws of physics" — invariants that
 never regress on any pass (permanent e2e B1–B6, no-commit/no-push gate B4/B14, delivery step B12).
 
 **How they fit:** the harness is the **floor** (nothing worse than the contract can ever be
@@ -398,7 +398,7 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
  coordinate `127.0.0.1:11434` reaches the live Ollama on the docker host), so they must RUN (not
  skip) — root resolution is the actual bug to fix, not a skip guard.
   - **(B20) NEVER declare a change "done" without running the loop gate first — this is a hard pre-flight, not optional.** Before reporting any OpenSpec change as complete (or before claiming "the harness is green / aligned / fixed"), the agent MUST execute the loop gate and report its real output:
-      1. **Preferred:** run `bash scripts/run-loop-harness.sh` (the loop-harness runner — it streams each stage's container/pytest/jest output to the terminal LIVE, prints a start banner + heartbeat on quiet stages, and ends with a per-stage PASS/FAIL/timeout summary; it wraps `make <stage>` in `setsid script … | tee` so nerdctl's forced `--tty` gets a console without deadlocking under an interactive shell). It runs all eight stages in order: `loop-collect` → `loop-unit` → `loop-ts-floor` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app`. (The standalone `make test-agents-*` / `make run-agentics` commands also self-provide a console via the Makefile `$(call docker_run, …)` helper, which uses `script` only when stdout is not a tty.)
+      1. **Preferred:** run `bash scripts/run-loop-harness.sh` (the loop-harness runner — it streams each stage's container/pytest/jest output to the terminal LIVE, prints a start banner + heartbeat on quiet stages, and ends with a per-stage PASS/FAIL/timeout summary; it wraps `make <stage>` in `setsid script … | tee` so nerdctl's forced `--tty` gets a console without deadlocking under an interactive shell). It runs all stages in order: `loop-collect` → `loop-unit` → `loop-ts-floor` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync`. (The standalone `make test-agents-*` / `make run-agentics` commands also self-provide a console via the Makefile `$(call docker_run, …)` helper, which uses `script` only when stdout is not a tty.)
          **HOW TO RUN (never make excuses):** long-running `make` targets (`run-agentics`, `build-app`, `test-app`, `loop-harness`, `loop-e2e`, `deliver-change`, `phase7-archive`, `release-flow`) MUST be launched via `terminal(background=true)` — that call executes on the **REAL HOST** (`/home/asimov/repository/git/projects/obsidian-timestamp-utility`), where `make`/`docker`/rootless `nerdctl`/live Ollama all live. The foreground sandbox (`/workspace`) has NO docker/nerdctl and will print `docker: command not found` — that is EXPECTED and is NOT a blocker; the host has it. **Never say "can't run from here" / "environment absent" — the host runs `make` for you.** Drive verification through `make` with REAL output, always.
       2. **If the full `make loop-harness` cannot complete in the session** (e.g. an explicit
          timeout, or a stage is deliberately disabled via env), the agent MUST STILL run the
@@ -437,8 +437,11 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
          sections AND the bump PART.
        - **`make lint-commits`** — run `commitlint` over the squashed range / HEAD; the changelog lint
          gate (fail-closed on any invalid message).
-       - **`make install-git-hooks`** — wire `git-hooks/commit-msg` into `.git/hooks` so every
-         manual `git commit` is linted by commitlint (per-commit Conventional-Commit gate).
+       - **`make install-git-hooks`** — wire `git-hooks/commit-msg` (per-commit Conventional-Commit
+         lint) and `git-hooks/pre-commit` (trailing-whitespace auto-fix) into `.git/hooks` so every
+         manual `git commit` is linted. The pre-commit hook only strips trailing whitespace from
+         staged text files and **never exits non-zero**, so it is inert under the loop (which performs
+         no `git commit`).
        - **`make changelog`** — regenerate sectioned `CHANGELOG.md` (git_chglog; one `## <version>`
          section per git tag, so a local `v<version>` tag after bump yields a viewable new section).
        - **`make release-notes`** — refresh the README release-notes block.
@@ -543,6 +546,26 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
        3. `make squash-commits` is a HUMAN-TRIGGERED command only. The agent may mention it as an
           option, but must not execute it unless the human approved it for the current branch.
      B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md`.
+  - **(B26) AGENT MAY COMMIT/MERGE ITS OWN CHANGES on a non-main branch when the PRE-COMMIT HOOK
+     PASSES.** The agent is permitted to `git commit` (and `git merge`/`git cherry-pick`) its OWN
+     work-in-progress — e.g. landing this feature branch's OpenSpec change, scripts, Makefile, and
+     doc-sync edits — so it can iterate productively without waiting for a human to commit each
+     step. The permission is bounded by two hard conditions:
+       1. **Branch guard:** the current branch MUST NOT be `main` or `origin/main` (nor any other
+          protected branch). On `main`, B4/B14/B25 still forbid the agent from committing/pushing on
+          its own — a human triggers that.
+       2. **Hook guard:** the `git-hooks/pre-commit` (gitleaks secret scan + trailing-whitespace) MUST
+          pass. The agent commits ONLY through the normal `git commit` path so the hook runs; it
+          NEVER uses `--no-verify`. If the hook fails, the commit is blocked and the agent fixes the
+          underlying issue (or stops) rather than bypassing the guard.
+       3. **Still forbidden (human-only):** `git push` (B14), `make squash-commits`, `git rebase -i`
+          with squash/fixup, and `git reset --soft` + collapse (B25). This behaviour ADDS commit/merge
+          latitude on feature branches; it does NOT lift the no-push / no-squash / no-force gates.
+       4. Commits should be atomic and conventionally-scoped (the `git-hooks/commit-msg` lint applies).
+          The agent keeps `tasks.md` ticked as work is verified (B16) and re-runs `make check-docs-sync`
+          when it edits a sync doc.
+     B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md` and
+     `docs/openspec-engineering-loop-harness.md`.
   - **(B7.1) The deterministic floor runs in EVERY mode (incl. fast).** `route_hitl` in
     `composable_workflows.py` previously returned `output_result` when `TEST_FAST_MODE=1` (set by
     `tests/integration/conftest.py` to skip the npm-test phase), which bypassed `integration_testing`
@@ -600,17 +623,18 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
          code lingers and the next run starts clean).
       3. **Re-run** `make run-agentics` to regenerate from the corrected spec, then
          `make build-app` + `make test-app` until green.
-  - **(B12) Delivery gap — the verified worktree TS MUST reach the active branch.** The
-    agentic pipeline generates + verifies TS **inside a git worktree** (`worktrees/<name>`,
-    branch `feat/<name>`). The harness MUST NOT stop there: a feature that is green only in the
-    worktree and never lands on the branch it targets is a failed delivery. After `make
-    build-app` + `make test-app` are green in/for the worktree, the agent MUST pull the verified
-    `src/main.ts` + `src/__tests__/main.test.ts` back onto the **current branch's working tree**
-    (e.g. `make deliver-change CHANGE=<name>`, which copies the worktree files into the repo tree).
-    This is a file copy only — it does NOT commit/push (B4); committing remains a deliberate human
-    step. The agent must NEVER declare a change "done" while its generated TS still lives only in
-    the worktree. (Pitfall: AGENTS.md Phase 5's "the old TS remains until you deliberately merge
-    the worktree" previously let verified code die in the worktree — B12 overrides that silence.)
+  - **(B12) Delivery gap — verified worktree TS MUST reach the target branch as the PR.** The
+    pipeline generates + verifies TS **inside a git worktree** (`worktrees/<name>`, branch
+    `feat/<name>`). The harness MUST NOT stop there: a feature green only in the worktree that never
+    lands on its target branch is a failed delivery. The agent delivers by **pushing the worktree
+    branch as the PR** (`git push origin feat/<name>`, or `make openspec-flow NAME=<name> PUSH=1`) —
+    it MUST NOT copy generated TS back into the parent working tree (that would re-introduce
+    pollution; ALL artifacts stay in the worktree by design — see `openspec-change-worktree-flow`).
+    Corrections redeliver via `make openspec-redeliver NAME=<name>` (`git push --force-with-lease`
+    to the SAME PR branch only; never `main`). Never declare a change "done" while its worktree
+    branch (`feat/<name>`) has not been delivered. (Earlier wording told the agent to
+    `make deliver-change` — a file copy onto the current branch — which conflicts with the
+    worktree-confinement invariant; this override supersedes it.)
     **Bounded self-correct loop (≈5 e2e attempts):** repeat the fix-spec → restore → re-run
     sequence for up to ~5 full e2e runs (`make run-agentics` with that spec file). Each failed
     attempt MUST first try a **different adjustment to the spec/contract file** (tasks.md
@@ -635,8 +659,8 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
   stage order, the `loop-ts-floor` guard, or the B-behaviour range:
   1. **`Makefile`** — the executable gates + canonical stage-order comment; `make loop-harness`
      runs `loop-collect` → `loop-unit` → `loop-ts-floor` → `loop-unit-real` → `loop-e2e`
-     → `loop-integration` → `loop-build-app` → `loop-test-app` → `check-docs-sync` (final).
-  2. **`AGENTS.md`** — this file: the authoritative narrative + the B1–B25 durable behaviours.
+           → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync` (final).
+  2. **`AGENTS.md`** — this file: the authoritative narrative + the B1–B26 durable behaviours.
   3. **`hermes/skills/openspec-loop-harness.md`** — the loadable skill mirror of AGENTS.md.
   4. **`docs/openspec-engineering-loop-harness.md`** — the human-readable technical reference
      (named by B8 itself as authoritative; MUST be kept in the sync set, not treated as a 4th
@@ -648,7 +672,7 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
      marked `@pytest.mark.e2e`) — the runtime proof the loop works.
   Before claiming "the loop is green / aligned", run `make check-docs-sync` (the final loop stage)
   and confirm it PASSES: all sync docs agree on the 8-stage order + final `check-docs-sync`, the
-  `loop-ts-floor` guard, the B1–B25 behaviours, and the live-test skip rule (`OLLAMA_HOST` only,
+  `loop-ts-floor` guard, the B1–B26 behaviours, and the live-test skip rule (`OLLAMA_HOST` only,
   not `GITHUB_TOKEN`). A change is NOT done while any of the sync docs disagree.
 - The harness is the OpenSpec change: `proposal.md` defines *why*, `specs/**` defines *what must
   hold*, `tasks.md` defines *the steps to run*. The agentic pipeline turns tasks into code+tests.
@@ -678,12 +702,19 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>`, which shells out to `openspec new change` per B15) +
-  tasks, validate it, and start the loop — according to the **per-channel trigger**:
+  tasks, validate it, and **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree
+  `feat/<name>`, scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives
+  on green, finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing
+  `feat/<name>` as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER
+  touched (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -692,3 +723,43 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
   `make openspec-new` / `openspec new change`; do NOT limit itself to kanban tooling.  The reusable directive lives in the Hermes skill
   `request-to-openspec` (loaded at request entry). Mirrored in `openspec-loop-harness.md` and
   `docs/openspec-engineering-loop-harness.md` (B8).
+
+---
+
+## Secret scanning (gitleaks)
+
+The broken TruffleHog GitHub Action was replaced by **gitleaks** (the de-facto open-source scanner).
+The actual secret **scan** lives in the pre-commit hook + CI (NOT a loop-harness stage); the
+secret-scanner's own **pytest suite** runs as a loop-harness stage (`loop-secret-scan-tests`).
+
+- **Engine:** `scripts/secret_scanner.py` delegates 100% of detection to gitleaks — no homemade
+  regex/entropy detector. It is the LOCAL fail-closed **hook** guard (dev-side), not a loop command.
+- **Config:** `.gitleaks.toml` uses `[extend] useDefault = true` plus repo-local `allowlist` entries
+  for test fixtures, docs, dependency/build caches (`.venv`, `node_modules`, `__pycache__`, and so on),
+  and `.env`/`.git`. **Do NOT replace `useDefault = true` with an empty `path`** — that silently
+  disables the entire default ruleset.
+- **Scan lives in the hook + CI (NOT the loop):** the gitleaks repo scan runs in `git-hooks/pre-commit`
+  (`python3 scripts/secret_scanner.py --staged`) and `git-hooks/commit-msg` (`--message-file`), and in
+  CI (`.github/workflows/trufflehog.yml`, `gitleaks/gitleaks-action@v2`). A detected secret blocks the
+  commit / fails CI. A standalone `make loop-secret-scan` target exists for on-demand scans but is NOT
+  a loop stage (the loop must not re-scan the tree — the hook already guards every commit).
+- **Loop stage = the scanner's own tests (containerized, B9):** `make loop-secret-scan-tests` builds
+  `secret-scan-tests-image` (real gitleaks + pytest) and runs `tests/test_secret_scanner*.py` **inside
+  the `gitleaks-tests` compose container** (`docker-compose-files/gitleaks-tests.yaml`), exercising the
+  REAL gitleaks binary (no mocks on detection). It sits between `loop-test-app` and `check-docs-sync`
+  in the canonical stage order. This verifies the scanner's detection logic itself every loop run.
+- **No duplicate scan commands:** the Makefile has exactly ONE on-demand scan target (`loop-secret-scan`,
+  alias `check-secrets`); it does NOT shell out to `python3` or a bare host `gitleaks` binary — docker
+  compose only, like every other harness gate. `make secret-scan-image` / `make secret-scan-tests-image`
+  build images; `make test-secret-scanner` runs the pytest suites on the host. `loop-secret-scan-tests`
+  is the canonical loop entry that runs the suite containerized.
+- **Hooks (fail-closed, local dev guard):** `git-hooks/pre-commit` runs `python3 scripts/secret_scanner.py --staged`;
+  `git-hooks/commit-msg` runs `python3 scripts/secret_scanner.py --message-file`. A detected secret
+  rejects the commit. Installed via `make install-git-hooks`.
+- **CI:** `.github/workflows/trufflehog.yml` is a gitleaks workflow (`gitleaks/gitleaks-action@v2`,
+  `fetch-depth: 0`, `GITLEAKS_CONFIG=.gitleaks.toml`).
+- **Tests:** `tests/test_secret_scanner.py` (hermetic unit) + `tests/test_secret_scanner_integration.py`
+  (real gitleaks binary, no mocks on detection). Run with `make test-secret-scanner` (host) or via the
+  loop stage `loop-secret-scan-tests` (containerized).
+- **Credential hygiene:** never put real API keys/tokens in source or tests. Use documented example
+  shapes (e.g. `AKIA…EXAMPLE`, `xoxb-…`) or `[REDACTED]`.

--- a/tests/fixtures/check_docs_sync/drift_reorder/docs/openspec-engineering-loop-harness.md
+++ b/tests/fixtures/check_docs_sync/drift_reorder/docs/openspec-engineering-loop-harness.md
@@ -8,7 +8,7 @@
 > 2. **Harness engineering** — the Python "agentics" pipeline (`agents/agentics/`) and
 >    the deterministic merge floor that writes your `src/main.ts` / `src/__tests__/main.test.ts`.
 > 3. **Loop engineering** — the bounded self‑correcting build→test→fix loop and the
->    durable behaviours **B1–B25** that the loop must always honour.
+>    durable behaviours **B1–B26** that the loop must always honour.
 >
 > It also documents the **file structure**, every file that creates the harness's
 > behaviour, and a **how‑to‑use** walkthrough for authoring a new feature.
@@ -21,7 +21,7 @@ at repo root, the previous `docs/openspec-loop-harness-guide.md`) are historical
 ## 0. Fundamentals — what "harness" and "loop" engineering mean
 
 Before the technical detail, understand the two disciplines this whole system is built on.
-Everything below (OpenSpec, the Python pipeline, the Makefile, B1–B25) is just a concrete
+Everything below (OpenSpec, the Python pipeline, the Makefile, B1–B26) is just a concrete
 implementation of these two ideas. If you internalise this section, the rest of the document
 reads as "here is *how* we do harness + loop engineering in this repo."
 
@@ -91,7 +91,7 @@ A well‑engineered loop has four parts:
    a loop with no escalation hides real defects.
 
 The loop is also where **durability** lives: the invariants that must hold on *every* pass
-(B1–B25) — a permanent regression e2e that outlives every feature (B1–B6), the no‑commit/no‑push
+(B1–B26) — a permanent regression e2e that outlives every feature (B1–B6), the no‑commit/no‑push
 gate (B4/B14), the delivery step that moves verified code out of the worktree onto the branch
 (B12). These are the loop's "laws of physics": conditions that never regress no matter how many
 times you go round.
@@ -105,7 +105,7 @@ gate is green, then stop."
 | Discipline | Job | Answers the question | In this repo |
 |-----------|-----|----------------------|--------------|
 | **Harness engineering** | *Constrain* the generator into a verifiable shape | "How do I make one generation trustworthy?" | OpenSpec contract as source of truth + `CodeIntegratorAgent` deterministic merge floor + omission guard + B9 perms + git‑HEAD restore |
-| **Loop engineering** | *Correct* the generator across attempts until an objective gate passes | "How do I make the system converge on correct, and know when to stop?" | `make build-app`/`make test-app` gate + spec‑first self‑correct loop (bounded ~5) + durable behaviours B1–B25 + delivery step B12 |
+| **Loop engineering** | *Correct* the generator across attempts until an objective gate passes | "How do I make the system converge on correct, and know when to stop?" | `make build-app`/`make test-app` gate + spec‑first self‑correct loop (bounded ~5) + durable behaviours B1–B26 + delivery step B12 |
 
 The harness is the **floor** (nothing worse than this can be written); the loop is the **ratchet**
 (each pass can only move toward green, and the invariants never slip back). The rest of this
@@ -148,7 +148,7 @@ Three non‑negotiable principles:
 
 ```
 obsidian-timestamp-utility/
-├── AGENTS.md                         # Repo‑level authority: phase flow + B1–B25 summary
+├── AGENTS.md                         # Repo‑level authority: phase flow + B1–B26 summary
 ├── Makefile                          # ALL execution entry points (docker compose only, no Dagger)
 ├── docker-compose-files/
 │   ├── agents.yaml                   # agentics / unit‑test‑agents / integration‑test‑agents services
@@ -547,18 +547,23 @@ if invoking docker compose outside the Makefile. World‑readable on a private r
 
 `make run-agentics` generates + verifies TS **inside a worktree**. The harness must NOT stop
 there: a feature green only in the worktree that never lands on its target branch is a failed
-delivery. After `build-app`+`test-app` are green, pull the verified files back onto the current
-branch's working tree:
+delivery. Deliver it by **pushing the worktree branch as the PR** — NOT by copying files back into
+the parent working tree (that would re-introduce pollution; ALL artifacts stay in the worktree by
+design — see `openspec-change-worktree-flow`):
 
 ```bash
-make deliver-change CHANGE=<name>     # copies worktree src/main.ts + main.test.ts → repo (file copy, NO commit)
+make openspec-flow NAME=<name> PUSH=1     # creates worktree, archives on green, finalizes, pushes feat/<name> as PR
+# corrections after a pass:
+make openspec-redeliver NAME=<name>        # re-enters worktree, re-squashes, force-pushes to the SAME PR branch (--force-with-lease, never main)
 ```
 
-Never declare a change "done" while its generated TS still lives only in the worktree.
+Never declare a change "done" while its worktree branch (`feat/<name>`) has not been delivered.
+(The earlier `make deliver-change` file-copy directive conflicts with the worktree-confinement
+invariant and is superseded by this PR-push model.)
 
 ---
 
-## 6. Durable behaviours B1–B25 (must always hold, never regress)
+## 6. Durable behaviours B1–B26 (must always hold, never regress)
 
 | ID | Behaviour |
 |----|-----------|
@@ -573,14 +578,15 @@ Never declare a change "done" while its generated TS still lives only in the wor
 | **B9** | Rootless nerdctl bind‑mount permissions (READ+WRITE). Whole repo world‑readable; container write targets world‑writable. Enforced by the `b9-perms` Makefile prerequisite. |
 | **B10** | **NO hard‑coded generated TS/test code in Python** — only contract‑steered. Generated TS bodies live *only* in the change's `tasks.md`/`spec.md` markers; Python only parses + merges + injects verbatim. |
 | **B11** | On generated‑TS failure: **fix the SPEC, then restore, then re‑run** — never edit TS by hand. Bounded ~5‑attempt self‑correct loop; only then may Python floor code be touched as last resort. |
-| **B12** | Delivery gap — verified worktree TS MUST reach the active branch (`make deliver-change`). Never declare done while TS lives only in the worktree. |
+| **B12** | Delivery gap — verified worktree TS MUST reach the target branch as the PR (`make openspec-flow NAME=<name> PUSH=1` → `git push feat/<name>`; corrections via `make openspec-redeliver` force-push to the SAME PR branch). NEVER a file copy into the parent working tree (worktree-confinement invariant). Never declare done while the worktree branch is undelivered. |
 | **B13** | Python *floor* defects are fixed directly, not via spec round‑trips. If the defect is in the deterministic floor itself, fix `CodeIntegratorAgent` — that is the correct spec‑steered fix; only the *merge logic* is corrected, the contract TS body still comes from the spec. |
 | **B14** | Commit/push gating for *new* code (human‑only, behaviour‑scoped). Code is committed ONLY if NEW; pushed ONLY if that new code is part of a behaviour. Floor/integrator Python fixes MAY be committed (and pushed only when part of a committed behaviour) **once**: `build-app`=0, `test-app`=0, passing‑test count **>** previous run, and all OpenSpec checks clean. Rule of thumb: commit only if new AND build works AND tests pass > last run AND OpenSpec clean; push only if that commit is the behaviour landing. **Never squash/rebase/force‑push.** |
 | **B15** | **GitHub issue → local OpenSpec change via the OpenSpec CLI (seed‑then‑generate).** When a change is sourced from a GitHub issue, the agentic code MUST turn it into a local OpenSpec change by **shelling out to `openspec new change ticket<N>`** (the same CLI step a human runs) — never hand‑writing the directory, never a raw `Path.write_text` for the directory shape. `fetch_issue_agent.py` calls `openspec_loader.create_change_from_issue(url, title, body)` after the fetch; that scaffolds via the CLI, fills `proposal.md`/`specs/<cap>/spec.md`/`tasks.md` from the issue, and re‑points generation to `openspec:ticket<N>` so the rest of the loop runs offline. The change name is derived deterministically from the issue URL (`.../issues/20` → `ticket20`), so re‑runs are idempotent. The seeded `openspec/changes/ticket<N>/` is a RUNTIME artifact and MUST NOT be committed (extends B4); `ticket20`/`ticket22` e2e tests generate + clean it up in `finally`. Keeps B10 honest: the exact `openspec new change` a human runs is the one the pipeline runs. |
 | **B16** | **Task‑completion discipline — tick as you verify, never leave open tasks, archive gate fails closed.** `make phase7-archive` runs `openspec_loader.assert_no_open_tasks` BEFORE `openspec archive` and refuses (non‑zero exit, no spec merge) if any `- [ ]` task remains. A change is "done" only when all tasks are ticked AND verified AND archived. `make loop-tasks` lists open/done per change so the backlog is never invisible. |
-| **B17** | **Integration suite is a mandatory loop phase; no dead tests; live tests skip cleanly.** `make loop-harness` runs EIGHT loop stages plus a FINAL B8 doc-sync gate: a collection guard (gate 0), a strict TS test/command floor (gate 0.5), followed by six gates (1–6): `loop-collect` (hermetic collection guard) → `loop-ts-floor` (STRICT TS test/command floor — FAIL if the current branch's `describe`/leaf `it`/`test`/jest-collected/`addCommand` counts drop below `origin/main`) → `loop-unit` (mocked, hermetic) → `loop-unit-real` (REAL agent unit tests on live Ollama, no mocks) → `loop-e2e` (B1/B3 e2e) → `loop-integration` (broad suite) → `loop-build-app` → `loop-test-app`, then `check-docs-sync` (FINAL B8 gate — FAIL if any sync doc drifts on stage order / `loop-ts-floor` / B-range). No dead duplicates; live tests `skipif` cleanly on `OLLAMA_HOST`. |
+| **B17** | **Integration suite is a mandatory loop phase; no dead tests; live tests skip cleanly.** `make loop-harness` runs EIGHT loop stages plus a FINAL B8 doc-sync gate: a collection guard (gate 0), a strict TS test/command floor (gate 0.5), followed by six gates (1–6): `loop-collect` (hermetic collection guard) → `loop-ts-floor` (STRICT TS test/command floor — FAIL if the current branch's `describe`/leaf `it`/`test`/jest-collected/`addCommand` counts drop below `origin/main`) → `loop-unit` (mocked, hermetic) → `loop-unit-real` (REAL agent unit tests on live Ollama, no mocks) → `loop-e2e` (B1/B3 e2e) → `loop-integration` (broad suite) → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` (secret-scanner pytest suite, containerized, real gitleaks, fail-closed; the actual gitleaks tree-scan lives in the pre-commit hook + CI, not the loop), then `check-docs-sync` (FINAL B8 gate — FAIL if any sync doc drifts on stage order / `loop-ts-floor` / B-range). No dead duplicates; live tests `skipif` cleanly on `OLLAMA_HOST`. |
 | **B18** | **Run the agents' REAL unit tests, not only the mocked ones.** The loop MUST execute BOTH the hermetic mocked unit run (`loop-unit` → `test-agents-unit-mock`) AND the real, non‑mocked agent unit run (`loop-unit-real` → `test-agents-unit`, live Ollama) as gates 1 and 2. Reporting "agent tests green" after ONLY the mocked run is INCOMPLETE. `test-agents-unit` MUST be run when Ollama is reachable and its result reported alongside — not instead of — the mocked run. If Ollama is unreachable, `loop-unit-real` SKIPS (must not error) but the agent MUST state the real unit gate did not run. |
 | **B20** | **NEVER declare a change "done" without running the loop gate first — hard pre-flight.** Before claiming any OpenSpec change complete (or "harness green/aligned/fixed"), run the gate and report real output. Preferred: `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`, also `make loop-trigger`) — all eight stages. **HOW TO RUN: long-running `make` targets (`run-agentics`, `build-app`, `test-app`, `loop-harness`, `loop-e2e`, `deliver-change`, `phase7-archive`, `release-flow`) MUST be launched via `terminal(background=true)` — that call executes on the REAL HOST (`/home/asimov/repository/git/projects/obsidian-timestamp-utility`), where `make`/`docker`/rootless `nerdctl`/live Ollama all live. The foreground sandbox (`/workspace`) has NO docker/nerdctl and will say `docker: command not found` — that is EXPECTED and is NOT a blocker; the host has it.** The host provides rootless `nerdctl` AND a live Ollama (host-networked, so `127.0.0.1:11434` reaches it — B19), so `loop-unit-real` and `loop-e2e` are EXPECTED to RUN, not skip. Only STILL run the hermetic gates `make loop-collect` + `make loop-ts-floor` + `make loop-unit` (no external dep) when a stage truly cannot finish in the session; they MUST be green before any "done". Report honestly (PASS/SKIP/FAIL, failing stage named); never claim green if `loop-unit`/`loop-collect` is red; **never claim "can't run from here" — the host runs `make` for you.** Fix root cause and re-run. (B4/B14: no git commit/push from the gate.) |
+| **B26** | **AGENT MAY COMMIT/MERGE ITS OWN CHANGES on a non‑main branch when the PRE‑COMMIT HOOK PASSES.** Permitted to `git commit` (and `git merge`/`git cherry‑pick`) its OWN work‑in‑progress on a feature branch so it can iterate productively. Bounded by: (1) branch guard — current branch MUST NOT be `main`/`origin/main`/protected; (2) hook guard — `git-hooks/pre-commit` (gitleaks + trailing‑whitespace) MUST pass; the agent commits only via the normal `git commit` path, NEVER `--no-verify`. Still forbidden (human‑only): `git push` (B14), `make squash-commits`, `git rebase -i` squash/fixup, `git reset --soft` collapse (B25). Adds commit/merge latitude on feature branches; does NOT lift no‑push/no‑squash/no‑force. (B21–B25 are documented in `AGENTS.md`.) |
 
 ---
 
@@ -714,12 +720,19 @@ Follow the §5.2 self‑correct loop:
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>` → `openspec new change`, per B15) + tasks, validate it, and
-  start the loop — according to the **per-channel trigger**:
+  **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree `feat/<name>`,
+  scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives on green,
+  finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing `feat/<name>`
+  as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER touched
+  (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -737,7 +750,7 @@ This file, `AGENTS.md`, and `hermes/skills/openspec-loop-harness.md` are the **s
 truth**. When you change a behaviour, constraint, command, or pitfall in **any one** of them,
 mirror it in the **other two** before considering the change done:
 
-- Repo authority: `AGENTS.md` (phase flow + B1–B25 summary).
+- Repo authority: `AGENTS.md` (phase flow + B1–B26 summary).
 - Skill mirror: `hermes/skills/openspec-loop-harness.md` (operator‑level detail + pitfalls).
 - This guide: `docs/openspec-engineering-loop-harness.md` (human‑readable technical reference).
 

--- a/tests/fixtures/check_docs_sync/drift_reorder/hermes/skills/openspec-loop-harness.md
+++ b/tests/fixtures/check_docs_sync/drift_reorder/hermes/skills/openspec-loop-harness.md
@@ -24,7 +24,7 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
   walk), (3) **diagnose & correct by fixing the SOURCE OF TRUTH not the symptom** (edit the spec,
   restore, re-run — never hand-edit generated TS, B11; each pass a *different* tweak), and
   (4) **terminate** (bounded ~5 attempts, then escalate to fixing the Python floor B13). Durable
-  invariants B1–B25 are the loop's "laws of physics" that never regress on any pass.
+  invariants B1–B26 are the loop's "laws of physics" that never regress on any pass.
 - **How they fit:** the harness is the **floor** (nothing worse can be written); the loop is the
   **ratchet** (each pass only moves toward green, invariants never slip). Full write-up:
   `docs/openspec-engineering-loop-harness.md` §0.
@@ -181,12 +181,19 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>` → `openspec new change`, per B15) + tasks, validate it, and
-  start the loop — according to the **per-channel trigger**:
+  **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree `feat/<name>`,
+  scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives on green,
+  finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing `feat/<name>`
+  as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER touched
+  (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -196,7 +203,7 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
   `docs/openspec-engineering-loop-harness.md` (B8). The reusable directive is the Hermes skill
   `request-to-openspec` (loaded at request entry).
 
-## Durable agent behaviours (B1–B25) — MUST always hold, never regress
+## Durable agent behaviours (B1–B26) — MUST always hold, never regress
 
 These are standing rules for the agent (also in `AGENTS.md`). They are enforced by
 `make phase7-archive` and the persistent harness
@@ -269,7 +276,7 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
   different behaviour. The full B8 sync set (enforced by `make check-docs-sync`, the FINAL loop
   stage) also includes `Makefile`, `docs/openspec-engineering-loop-harness.md`, and
   `scripts/run-loop-harness.sh` — all MUST agree on the 8-stage order + final `check-docs-sync`,
-  the `loop-ts-floor` guard, and the B1–B25 range; a drift there fails the loop.
+  the `loop-ts-floor` guard, and the B1–B26 range; a drift there fails the loop.
 - **(B9) Rootless nerdctl bind-mount permissions (READ + WRITE).** Execution is docker compose
   with **rootless nerdctl**, which remaps the container uid (1000) to the host **`other`** class.
   Every file/dir the container must READ (the whole repo, since compose mounts `..:/project`)
@@ -323,15 +330,17 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
   `_expected_contract_for_change`) only reads the spec contract and merges it deterministically —
   it must never author TS bodies. Hand-editing generated TS is forbidden because it bypasses the
   deterministic merge floor and desyncs the spec from the code.
-- **(B12) Delivery gap — verified worktree TS MUST reach the active branch.** The pipeline
+- **(B12) Delivery gap — verified worktree TS MUST reach the target branch as the PR.** The pipeline
   generates + verifies TS **inside a git worktree** (`worktrees/<name>`, branch `feat/<name>`).
   The harness MUST NOT stop there: a feature green only in the worktree that never lands on its
-  target branch is a failed delivery. After `build-app`+`test-app` are green, the agent MUST pull
-  the verified `src/main.ts` + `src/__tests__/main.test.ts` back onto the **current branch's
-  working tree** (e.g. `make deliver-change CHANGE=<name>` — a file copy, NOT a commit; B4 holds).
-  Never declare a change "done" while its generated TS still lives only in the worktree. (AGENTS.md
-  Phase 5's "old TS remains until you deliberately merge the worktree" previously let verified
-  code die in the worktree — B12 overrides that silence.)
+  target branch is a failed delivery. The agent delivers by **pushing the worktree branch as the PR**
+  (`git push origin feat/<name>`, or `make openspec-flow NAME=<name> PUSH=1`) — it MUST NOT copy
+  generated TS back into the parent working tree (that would re-introduce pollution; ALL artifacts
+  stay in the worktree by design — see `openspec-change-worktree-flow`). Corrections redeliver via
+  `make openspec-redeliver NAME=<name>` (`git push --force-with-lease` to the SAME PR branch only;
+  never `main`). Never declare a change "done" while its worktree branch has not been delivered.
+  (Earlier wording told the agent to `make deliver-change` — a file copy onto the current branch —
+  which conflicts with the worktree-confinement invariant; this override supersedes it.)
 - **(B13) Python *floor* defects are fixed directly, not via spec round-trips.** B11's spec-first
   rule applies when the GENERATED TS/test is wrong. If the defect is in the *deterministic floor*
   itself (e.g. the integrator skips injecting the spec contract when the LLM already emitted a same-
@@ -431,7 +440,7 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
  `127.0.0.1:11434` reaches the live Ollama on the docker host), so they must RUN (not skip) — fix
  root resolution, never add an OLLAMA skip guard. (Closed the gap where `test_greetings_contract_unit.py` + `test_slim_refactor_invariants_unit.py` failed post-archive, and where `test_ticket20/ticket22/greetings` e2e errored on `FileNotFoundError: 'openspec'` due to `/app` root resolution.)
     - **(B20) NEVER declare a change "done" without running the loop gate first — hard pre-flight.** Before claiming any OpenSpec change complete (or "harness green/aligned/fixed"), run the gate and report real output:
-      1. **Preferred:** `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`) — all eight stages: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app`. Also `make loop-trigger`.
+      1. **Preferred:** `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`) — all stages: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync`. Also `make loop-trigger`.
       2. **If full `make loop-harness` can't finish** (live Ollama absent for `loop-e2e`/`loop-unit-real`, or npm build times out), STILL run the hermetic gates `make loop-collect` + `make loop-ts-floor` + `make loop-unit` (no external dep) — they MUST be green before any "done".
       3. **Report honestly:** actual per-stage PASS/SKIP/FAIL with the failing stage named. Never say "done/green" if `loop-unit`/`loop-collect` is red; fix the root cause and re-run. Rationale: the agent previously finished work (incl. AGENTS.md/skill edits) WITHOUT running the gate, leaving `make loop-unit` red. B20 makes the gate mandatory so regressions are caught before "done". (B4/B14: no git commit/push from the gate.)
     - **(B21) HITL is OPT-IN and loop-excluded — never a blocking prompt in automation.** `HITLNode`
@@ -498,6 +507,14 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
       graph. The agent MAY commit (B23) and merge/cherry-pick, but must NOT rewrite/squash existing
       history. If history is messy (leaked throwaway commits), FLAG it for the human and ask — do not
       decide unilaterally. `make squash-commits` is human-triggered only. B8: mirror in AGENTS.md.
+    - **(B26) AGENT MAY COMMIT/MERGE ITS OWN CHANGES on a non-main branch when the PRE-COMMIT HOOK
+      PASSES.** Permitted to `git commit` (and `git merge`/`git cherry-pick`) its OWN work-in-progress
+      on a feature branch so it can iterate productively. Bounded by: (1) branch guard — current
+      branch MUST NOT be `main`/`origin/main`/protected; (2) hook guard — `git-hooks/pre-commit`
+      (gitleaks + trailing-whitespace) MUST pass; the agent commits only via the normal `git commit`
+      path, NEVER `--no-verify`. Still forbidden (human-only): `git push` (B14), `make squash-commits`,
+      `git rebase -i` squash/fixup, `git reset --soft` collapse (B25). Adds commit/merge latitude on
+      feature branches; does NOT lift no-push/no-squash/no-force. B8: mirror in AGENTS.md + harness doc.
     ## Plan-B merge refactor (integrator-merge-refactor)
 
 - **Imports:** inject new `import` lines at the top (after the last existing top-level import).

--- a/tests/fixtures/check_docs_sync/drift_stage_removed/AGENTS.md
+++ b/tests/fixtures/check_docs_sync/drift_stage_removed/AGENTS.md
@@ -69,7 +69,7 @@ every spec requirement/scenario); (3) **diagnose & correct by fixing the SOURCE 
 symptom** — edit the OpenSpec spec/contract, restore the generated files to a clean baseline, and
 re-run; NEVER hand-edit generated TS (B11), and each pass must try a *different* correction; and
 (4) **terminate** — a bounded ~5 attempts with a clear escalation (fix the Python floor as a last
-resort, B13). The durable behaviours B1–B25 are the loop's "laws of physics" — invariants that
+resort, B13). The durable behaviours B1–B26 are the loop's "laws of physics" — invariants that
 never regress on any pass (permanent e2e B1–B6, no-commit/no-push gate B4/B14, delivery step B12).
 
 **How they fit:** the harness is the **floor** (nothing worse than the contract can ever be
@@ -398,7 +398,7 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
  coordinate `127.0.0.1:11434` reaches the live Ollama on the docker host), so they must RUN (not
  skip) — root resolution is the actual bug to fix, not a skip guard.
   - **(B20) NEVER declare a change "done" without running the loop gate first — this is a hard pre-flight, not optional.** Before reporting any OpenSpec change as complete (or before claiming "the harness is green / aligned / fixed"), the agent MUST execute the loop gate and report its real output:
-      1. **Preferred:** run `bash scripts/run-loop-harness.sh` (the loop-harness runner — it streams each stage's container/pytest/jest output to the terminal LIVE, prints a start banner + heartbeat on quiet stages, and ends with a per-stage PASS/FAIL/timeout summary; it wraps `make <stage>` in `setsid script … | tee` so nerdctl's forced `--tty` gets a console without deadlocking under an interactive shell). It runs all eight stages in order: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real`  → `loop-integration` → `loop-build-app` → `loop-test-app`. (The standalone `make test-agents-*` / `make run-agentics` commands also self-provide a console via the Makefile `$(call docker_run, …)` helper, which uses `script` only when stdout is not a tty.)
+      1. **Preferred:** run `bash scripts/run-loop-harness.sh` (the loop-harness runner — it streams each stage's container/pytest/jest output to the terminal LIVE, prints a start banner + heartbeat on quiet stages, and ends with a per-stage PASS/FAIL/timeout summary; it wraps `make <stage>` in `setsid script … | tee` so nerdctl's forced `--tty` gets a console without deadlocking under an interactive shell). It runs all stages in order: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real`  → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync`. (The standalone `make test-agents-*` / `make run-agentics` commands also self-provide a console via the Makefile `$(call docker_run, …)` helper, which uses `script` only when stdout is not a tty.)
          **HOW TO RUN (never make excuses):** long-running `make` targets (`run-agentics`, `build-app`, `test-app`, `loop-harness`, `loop-e2e`, `deliver-change`, `phase7-archive`, `release-flow`) MUST be launched via `terminal(background=true)` — that call executes on the **REAL HOST** (`/home/asimov/repository/git/projects/obsidian-timestamp-utility`), where `make`/`docker`/rootless `nerdctl`/live Ollama all live. The foreground sandbox (`/workspace`) has NO docker/nerdctl and will print `docker: command not found` — that is EXPECTED and is NOT a blocker; the host has it. **Never say "can't run from here" / "environment absent" — the host runs `make` for you.** Drive verification through `make` with REAL output, always.
       2. **If the full `make loop-harness` cannot complete in the session** (e.g. an explicit
          timeout, or a stage is deliberately disabled via env), the agent MUST STILL run the
@@ -437,8 +437,11 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
          sections AND the bump PART.
        - **`make lint-commits`** — run `commitlint` over the squashed range / HEAD; the changelog lint
          gate (fail-closed on any invalid message).
-       - **`make install-git-hooks`** — wire `git-hooks/commit-msg` into `.git/hooks` so every
-         manual `git commit` is linted by commitlint (per-commit Conventional-Commit gate).
+       - **`make install-git-hooks`** — wire `git-hooks/commit-msg` (per-commit Conventional-Commit
+         lint) and `git-hooks/pre-commit` (trailing-whitespace auto-fix) into `.git/hooks` so every
+         manual `git commit` is linted. The pre-commit hook only strips trailing whitespace from
+         staged text files and **never exits non-zero**, so it is inert under the loop (which performs
+         no `git commit`).
        - **`make changelog`** — regenerate sectioned `CHANGELOG.md` (git_chglog; one `## <version>`
          section per git tag, so a local `v<version>` tag after bump yields a viewable new section).
        - **`make release-notes`** — refresh the README release-notes block.
@@ -543,6 +546,26 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
        3. `make squash-commits` is a HUMAN-TRIGGERED command only. The agent may mention it as an
           option, but must not execute it unless the human approved it for the current branch.
      B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md`.
+  - **(B26) AGENT MAY COMMIT/MERGE ITS OWN CHANGES on a non-main branch when the PRE-COMMIT HOOK
+     PASSES.** The agent is permitted to `git commit` (and `git merge`/`git cherry-pick`) its OWN
+     work-in-progress — e.g. landing this feature branch's OpenSpec change, scripts, Makefile, and
+     doc-sync edits — so it can iterate productively without waiting for a human to commit each
+     step. The permission is bounded by two hard conditions:
+       1. **Branch guard:** the current branch MUST NOT be `main` or `origin/main` (nor any other
+          protected branch). On `main`, B4/B14/B25 still forbid the agent from committing/pushing on
+          its own — a human triggers that.
+       2. **Hook guard:** the `git-hooks/pre-commit` (gitleaks secret scan + trailing-whitespace) MUST
+          pass. The agent commits ONLY through the normal `git commit` path so the hook runs; it
+          NEVER uses `--no-verify`. If the hook fails, the commit is blocked and the agent fixes the
+          underlying issue (or stops) rather than bypassing the guard.
+       3. **Still forbidden (human-only):** `git push` (B14), `make squash-commits`, `git rebase -i`
+          with squash/fixup, and `git reset --soft` + collapse (B25). This behaviour ADDS commit/merge
+          latitude on feature branches; it does NOT lift the no-push / no-squash / no-force gates.
+       4. Commits should be atomic and conventionally-scoped (the `git-hooks/commit-msg` lint applies).
+          The agent keeps `tasks.md` ticked as work is verified (B16) and re-runs `make check-docs-sync`
+          when it edits a sync doc.
+     B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md` and
+     `docs/openspec-engineering-loop-harness.md`.
   - **(B7.1) The deterministic floor runs in EVERY mode (incl. fast).** `route_hitl` in
     `composable_workflows.py` previously returned `output_result` when `TEST_FAST_MODE=1` (set by
     `tests/integration/conftest.py` to skip the npm-test phase), which bypassed `integration_testing`
@@ -600,17 +623,18 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
          code lingers and the next run starts clean).
       3. **Re-run** `make run-agentics` to regenerate from the corrected spec, then
          `make build-app` + `make test-app` until green.
-  - **(B12) Delivery gap — the verified worktree TS MUST reach the active branch.** The
-    agentic pipeline generates + verifies TS **inside a git worktree** (`worktrees/<name>`,
-    branch `feat/<name>`). The harness MUST NOT stop there: a feature that is green only in the
-    worktree and never lands on the branch it targets is a failed delivery. After `make
-    build-app` + `make test-app` are green in/for the worktree, the agent MUST pull the verified
-    `src/main.ts` + `src/__tests__/main.test.ts` back onto the **current branch's working tree**
-    (e.g. `make deliver-change CHANGE=<name>`, which copies the worktree files into the repo tree).
-    This is a file copy only — it does NOT commit/push (B4); committing remains a deliberate human
-    step. The agent must NEVER declare a change "done" while its generated TS still lives only in
-    the worktree. (Pitfall: AGENTS.md Phase 5's "the old TS remains until you deliberately merge
-    the worktree" previously let verified code die in the worktree — B12 overrides that silence.)
+  - **(B12) Delivery gap — verified worktree TS MUST reach the target branch as the PR.** The
+    pipeline generates + verifies TS **inside a git worktree** (`worktrees/<name>`, branch
+    `feat/<name>`). The harness MUST NOT stop there: a feature green only in the worktree that never
+    lands on its target branch is a failed delivery. The agent delivers by **pushing the worktree
+    branch as the PR** (`git push origin feat/<name>`, or `make openspec-flow NAME=<name> PUSH=1`) —
+    it MUST NOT copy generated TS back into the parent working tree (that would re-introduce
+    pollution; ALL artifacts stay in the worktree by design — see `openspec-change-worktree-flow`).
+    Corrections redeliver via `make openspec-redeliver NAME=<name>` (`git push --force-with-lease`
+    to the SAME PR branch only; never `main`). Never declare a change "done" while its worktree
+    branch (`feat/<name>`) has not been delivered. (Earlier wording told the agent to
+    `make deliver-change` — a file copy onto the current branch — which conflicts with the
+    worktree-confinement invariant; this override supersedes it.)
     **Bounded self-correct loop (≈5 e2e attempts):** repeat the fix-spec → restore → re-run
     sequence for up to ~5 full e2e runs (`make run-agentics` with that spec file). Each failed
     attempt MUST first try a **different adjustment to the spec/contract file** (tasks.md
@@ -634,9 +658,9 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
   loop stage, `scripts/check-docs-sync.py`), which fails the loop if any disagree on the
   stage order, the `loop-ts-floor` guard, or the B-behaviour range:
   1. **`Makefile`** — the executable gates + canonical stage-order comment; `make loop-harness`
-     runs `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` 
-     → `loop-integration` → `loop-build-app` → `loop-test-app` → `check-docs-sync` (final).
-  2. **`AGENTS.md`** — this file: the authoritative narrative + the B1–B25 durable behaviours.
+     runs `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real`
+           → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync` (final).
+  2. **`AGENTS.md`** — this file: the authoritative narrative + the B1–B26 durable behaviours.
   3. **`hermes/skills/openspec-loop-harness.md`** — the loadable skill mirror of AGENTS.md.
   4. **`docs/openspec-engineering-loop-harness.md`** — the human-readable technical reference
      (named by B8 itself as authoritative; MUST be kept in the sync set, not treated as a 4th
@@ -648,7 +672,7 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
      marked `@pytest.mark.e2e`) — the runtime proof the loop works.
   Before claiming "the loop is green / aligned", run `make check-docs-sync` (the final loop stage)
   and confirm it PASSES: all sync docs agree on the 8-stage order + final `check-docs-sync`, the
-  `loop-ts-floor` guard, the B1–B25 behaviours, and the live-test skip rule (`OLLAMA_HOST` only,
+  `loop-ts-floor` guard, the B1–B26 behaviours, and the live-test skip rule (`OLLAMA_HOST` only,
   not `GITHUB_TOKEN`). A change is NOT done while any of the sync docs disagree.
 - The harness is the OpenSpec change: `proposal.md` defines *why*, `specs/**` defines *what must
   hold*, `tasks.md` defines *the steps to run*. The agentic pipeline turns tasks into code+tests.
@@ -678,12 +702,19 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>`, which shells out to `openspec new change` per B15) +
-  tasks, validate it, and start the loop — according to the **per-channel trigger**:
+  tasks, validate it, and **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree
+  `feat/<name>`, scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives
+  on green, finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing
+  `feat/<name>` as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER
+  touched (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -692,3 +723,43 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
   `make openspec-new` / `openspec new change`; do NOT limit itself to kanban tooling.  The reusable directive lives in the Hermes skill
   `request-to-openspec` (loaded at request entry). Mirrored in `openspec-loop-harness.md` and
   `docs/openspec-engineering-loop-harness.md` (B8).
+
+---
+
+## Secret scanning (gitleaks)
+
+The broken TruffleHog GitHub Action was replaced by **gitleaks** (the de-facto open-source scanner).
+The actual secret **scan** lives in the pre-commit hook + CI (NOT a loop-harness stage); the
+secret-scanner's own **pytest suite** runs as a loop-harness stage (`loop-secret-scan-tests`).
+
+- **Engine:** `scripts/secret_scanner.py` delegates 100% of detection to gitleaks — no homemade
+  regex/entropy detector. It is the LOCAL fail-closed **hook** guard (dev-side), not a loop command.
+- **Config:** `.gitleaks.toml` uses `[extend] useDefault = true` plus repo-local `allowlist` entries
+  for test fixtures, docs, dependency/build caches (`.venv`, `node_modules`, `__pycache__`, and so on),
+  and `.env`/`.git`. **Do NOT replace `useDefault = true` with an empty `path`** — that silently
+  disables the entire default ruleset.
+- **Scan lives in the hook + CI (NOT the loop):** the gitleaks repo scan runs in `git-hooks/pre-commit`
+  (`python3 scripts/secret_scanner.py --staged`) and `git-hooks/commit-msg` (`--message-file`), and in
+  CI (`.github/workflows/trufflehog.yml`, `gitleaks/gitleaks-action@v2`). A detected secret blocks the
+  commit / fails CI. A standalone `make loop-secret-scan` target exists for on-demand scans but is NOT
+  a loop stage (the loop must not re-scan the tree — the hook already guards every commit).
+- **Loop stage = the scanner's own tests (containerized, B9):** `make loop-secret-scan-tests` builds
+  `secret-scan-tests-image` (real gitleaks + pytest) and runs `tests/test_secret_scanner*.py` **inside
+  the `gitleaks-tests` compose container** (`docker-compose-files/gitleaks-tests.yaml`), exercising the
+  REAL gitleaks binary (no mocks on detection). It sits between `loop-test-app` and `check-docs-sync`
+  in the canonical stage order. This verifies the scanner's detection logic itself every loop run.
+- **No duplicate scan commands:** the Makefile has exactly ONE on-demand scan target (`loop-secret-scan`,
+  alias `check-secrets`); it does NOT shell out to `python3` or a bare host `gitleaks` binary — docker
+  compose only, like every other harness gate. `make secret-scan-image` / `make secret-scan-tests-image`
+  build images; `make test-secret-scanner` runs the pytest suites on the host. `loop-secret-scan-tests`
+  is the canonical loop entry that runs the suite containerized.
+- **Hooks (fail-closed, local dev guard):** `git-hooks/pre-commit` runs `python3 scripts/secret_scanner.py --staged`;
+  `git-hooks/commit-msg` runs `python3 scripts/secret_scanner.py --message-file`. A detected secret
+  rejects the commit. Installed via `make install-git-hooks`.
+- **CI:** `.github/workflows/trufflehog.yml` is a gitleaks workflow (`gitleaks/gitleaks-action@v2`,
+  `fetch-depth: 0`, `GITLEAKS_CONFIG=.gitleaks.toml`).
+- **Tests:** `tests/test_secret_scanner.py` (hermetic unit) + `tests/test_secret_scanner_integration.py`
+  (real gitleaks binary, no mocks on detection). Run with `make test-secret-scanner` (host) or via the
+  loop stage `loop-secret-scan-tests` (containerized).
+- **Credential hygiene:** never put real API keys/tokens in source or tests. Use documented example
+  shapes (e.g. `AKIA…EXAMPLE`, `xoxb-…`) or `[REDACTED]`.

--- a/tests/fixtures/check_docs_sync/drift_stage_removed/docs/openspec-engineering-loop-harness.md
+++ b/tests/fixtures/check_docs_sync/drift_stage_removed/docs/openspec-engineering-loop-harness.md
@@ -8,7 +8,7 @@
 > 2. **Harness engineering** — the Python "agentics" pipeline (`agents/agentics/`) and
 >    the deterministic merge floor that writes your `src/main.ts` / `src/__tests__/main.test.ts`.
 > 3. **Loop engineering** — the bounded self‑correcting build→test→fix loop and the
->    durable behaviours **B1–B25** that the loop must always honour.
+>    durable behaviours **B1–B26** that the loop must always honour.
 >
 > It also documents the **file structure**, every file that creates the harness's
 > behaviour, and a **how‑to‑use** walkthrough for authoring a new feature.
@@ -21,7 +21,7 @@ at repo root, the previous `docs/openspec-loop-harness-guide.md`) are historical
 ## 0. Fundamentals — what "harness" and "loop" engineering mean
 
 Before the technical detail, understand the two disciplines this whole system is built on.
-Everything below (OpenSpec, the Python pipeline, the Makefile, B1–B25) is just a concrete
+Everything below (OpenSpec, the Python pipeline, the Makefile, B1–B26) is just a concrete
 implementation of these two ideas. If you internalise this section, the rest of the document
 reads as "here is *how* we do harness + loop engineering in this repo."
 
@@ -91,7 +91,7 @@ A well‑engineered loop has four parts:
    a loop with no escalation hides real defects.
 
 The loop is also where **durability** lives: the invariants that must hold on *every* pass
-(B1–B25) — a permanent regression e2e that outlives every feature (B1–B6), the no‑commit/no‑push
+(B1–B26) — a permanent regression e2e that outlives every feature (B1–B6), the no‑commit/no‑push
 gate (B4/B14), the delivery step that moves verified code out of the worktree onto the branch
 (B12). These are the loop's "laws of physics": conditions that never regress no matter how many
 times you go round.
@@ -105,7 +105,7 @@ gate is green, then stop."
 | Discipline | Job | Answers the question | In this repo |
 |-----------|-----|----------------------|--------------|
 | **Harness engineering** | *Constrain* the generator into a verifiable shape | "How do I make one generation trustworthy?" | OpenSpec contract as source of truth + `CodeIntegratorAgent` deterministic merge floor + omission guard + B9 perms + git‑HEAD restore |
-| **Loop engineering** | *Correct* the generator across attempts until an objective gate passes | "How do I make the system converge on correct, and know when to stop?" | `make build-app`/`make test-app` gate + spec‑first self‑correct loop (bounded ~5) + durable behaviours B1–B25 + delivery step B12 |
+| **Loop engineering** | *Correct* the generator across attempts until an objective gate passes | "How do I make the system converge on correct, and know when to stop?" | `make build-app`/`make test-app` gate + spec‑first self‑correct loop (bounded ~5) + durable behaviours B1–B26 + delivery step B12 |
 
 The harness is the **floor** (nothing worse than this can be written); the loop is the **ratchet**
 (each pass can only move toward green, and the invariants never slip back). The rest of this
@@ -148,7 +148,7 @@ Three non‑negotiable principles:
 
 ```
 obsidian-timestamp-utility/
-├── AGENTS.md                         # Repo‑level authority: phase flow + B1–B25 summary
+├── AGENTS.md                         # Repo‑level authority: phase flow + B1–B26 summary
 ├── Makefile                          # ALL execution entry points (docker compose only, no Dagger)
 ├── docker-compose-files/
 │   ├── agents.yaml                   # agentics / unit‑test‑agents / integration‑test‑agents services
@@ -547,18 +547,23 @@ if invoking docker compose outside the Makefile. World‑readable on a private r
 
 `make run-agentics` generates + verifies TS **inside a worktree**. The harness must NOT stop
 there: a feature green only in the worktree that never lands on its target branch is a failed
-delivery. After `build-app`+`test-app` are green, pull the verified files back onto the current
-branch's working tree:
+delivery. Deliver it by **pushing the worktree branch as the PR** — NOT by copying files back into
+the parent working tree (that would re-introduce pollution; ALL artifacts stay in the worktree by
+design — see `openspec-change-worktree-flow`):
 
 ```bash
-make deliver-change CHANGE=<name>     # copies worktree src/main.ts + main.test.ts → repo (file copy, NO commit)
+make openspec-flow NAME=<name> PUSH=1     # creates worktree, archives on green, finalizes, pushes feat/<name> as PR
+# corrections after a pass:
+make openspec-redeliver NAME=<name>        # re-enters worktree, re-squashes, force-pushes to the SAME PR branch (--force-with-lease, never main)
 ```
 
-Never declare a change "done" while its generated TS still lives only in the worktree.
+Never declare a change "done" while its worktree branch (`feat/<name>`) has not been delivered.
+(The earlier `make deliver-change` file-copy directive conflicts with the worktree-confinement
+invariant and is superseded by this PR-push model.)
 
 ---
 
-## 6. Durable behaviours B1–B25 (must always hold, never regress)
+## 6. Durable behaviours B1–B26 (must always hold, never regress)
 
 | ID | Behaviour |
 |----|-----------|
@@ -573,14 +578,15 @@ Never declare a change "done" while its generated TS still lives only in the wor
 | **B9** | Rootless nerdctl bind‑mount permissions (READ+WRITE). Whole repo world‑readable; container write targets world‑writable. Enforced by the `b9-perms` Makefile prerequisite. |
 | **B10** | **NO hard‑coded generated TS/test code in Python** — only contract‑steered. Generated TS bodies live *only* in the change's `tasks.md`/`spec.md` markers; Python only parses + merges + injects verbatim. |
 | **B11** | On generated‑TS failure: **fix the SPEC, then restore, then re‑run** — never edit TS by hand. Bounded ~5‑attempt self‑correct loop; only then may Python floor code be touched as last resort. |
-| **B12** | Delivery gap — verified worktree TS MUST reach the active branch (`make deliver-change`). Never declare done while TS lives only in the worktree. |
+| **B12** | Delivery gap — verified worktree TS MUST reach the target branch as the PR (`make openspec-flow NAME=<name> PUSH=1` → `git push feat/<name>`; corrections via `make openspec-redeliver` force-push to the SAME PR branch). NEVER a file copy into the parent working tree (worktree-confinement invariant). Never declare done while the worktree branch is undelivered. |
 | **B13** | Python *floor* defects are fixed directly, not via spec round‑trips. If the defect is in the deterministic floor itself, fix `CodeIntegratorAgent` — that is the correct spec‑steered fix; only the *merge logic* is corrected, the contract TS body still comes from the spec. |
 | **B14** | Commit/push gating for *new* code (human‑only, behaviour‑scoped). Code is committed ONLY if NEW; pushed ONLY if that new code is part of a behaviour. Floor/integrator Python fixes MAY be committed (and pushed only when part of a committed behaviour) **once**: `build-app`=0, `test-app`=0, passing‑test count **>** previous run, and all OpenSpec checks clean. Rule of thumb: commit only if new AND build works AND tests pass > last run AND OpenSpec clean; push only if that commit is the behaviour landing. **Never squash/rebase/force‑push.** |
 | **B15** | **GitHub issue → local OpenSpec change via the OpenSpec CLI (seed‑then‑generate).** When a change is sourced from a GitHub issue, the agentic code MUST turn it into a local OpenSpec change by **shelling out to `openspec new change ticket<N>`** (the same CLI step a human runs) — never hand‑writing the directory, never a raw `Path.write_text` for the directory shape. `fetch_issue_agent.py` calls `openspec_loader.create_change_from_issue(url, title, body)` after the fetch; that scaffolds via the CLI, fills `proposal.md`/`specs/<cap>/spec.md`/`tasks.md` from the issue, and re‑points generation to `openspec:ticket<N>` so the rest of the loop runs offline. The change name is derived deterministically from the issue URL (`.../issues/20` → `ticket20`), so re‑runs are idempotent. The seeded `openspec/changes/ticket<N>/` is a RUNTIME artifact and MUST NOT be committed (extends B4); `ticket20`/`ticket22` e2e tests generate + clean it up in `finally`. Keeps B10 honest: the exact `openspec new change` a human runs is the one the pipeline runs. |
 | **B16** | **Task‑completion discipline — tick as you verify, never leave open tasks, archive gate fails closed.** `make phase7-archive` runs `openspec_loader.assert_no_open_tasks` BEFORE `openspec archive` and refuses (non‑zero exit, no spec merge) if any `- [ ]` task remains. A change is "done" only when all tasks are ticked AND verified AND archived. `make loop-tasks` lists open/done per change so the backlog is never invisible. |
-| **B17** | **Integration suite is a mandatory loop phase; no dead tests; live tests skip cleanly.** `make loop-harness` runs EIGHT loop stages plus a FINAL B8 doc-sync gate: a collection guard (gate 0), a strict TS test/command floor (gate 0.5), followed by six gates (1–6): `loop-collect` (hermetic collection guard) → `loop-ts-floor` (STRICT TS test/command floor — FAIL if the current branch's `describe`/leaf `it`/`test`/jest-collected/`addCommand` counts drop below `origin/main`) → `loop-unit` (mocked, hermetic) → `loop-unit-real` (REAL agent unit tests on live Ollama, no mocks)  (B1/B3 e2e) → `loop-integration` (broad suite) → `loop-build-app` → `loop-test-app`, then `check-docs-sync` (FINAL B8 gate — FAIL if any sync doc drifts on stage order / `loop-ts-floor` / B-range). No dead duplicates; live tests `skipif` cleanly on `OLLAMA_HOST`. |
+| **B17** | **Integration suite is a mandatory loop phase; no dead tests; live tests skip cleanly.** `make loop-harness` runs EIGHT loop stages plus a FINAL B8 doc-sync gate: a collection guard (gate 0), a strict TS test/command floor (gate 0.5), followed by six gates (1–6): `loop-collect` (hermetic collection guard) → `loop-ts-floor` (STRICT TS test/command floor — FAIL if the current branch's `describe`/leaf `it`/`test`/jest-collected/`addCommand` counts drop below `origin/main`) → `loop-unit` (mocked, hermetic) → `loop-unit-real` (REAL agent unit tests on live Ollama, no mocks)  (B1/B3 e2e) → `loop-integration` (broad suite) → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` (secret-scanner pytest suite, containerized, real gitleaks, fail-closed; the actual gitleaks tree-scan lives in the pre-commit hook + CI, not the loop), then `check-docs-sync` (FINAL B8 gate — FAIL if any sync doc drifts on stage order / `loop-ts-floor` / B-range). No dead duplicates; live tests `skipif` cleanly on `OLLAMA_HOST`. |
 | **B18** | **Run the agents' REAL unit tests, not only the mocked ones.** The loop MUST execute BOTH the hermetic mocked unit run (`loop-unit` → `test-agents-unit-mock`) AND the real, non‑mocked agent unit run (`loop-unit-real` → `test-agents-unit`, live Ollama) as gates 1 and 2. Reporting "agent tests green" after ONLY the mocked run is INCOMPLETE. `test-agents-unit` MUST be run when Ollama is reachable and its result reported alongside — not instead of — the mocked run. If Ollama is unreachable, `loop-unit-real` SKIPS (must not error) but the agent MUST state the real unit gate did not run. |
 | **B20** | **NEVER declare a change "done" without running the loop gate first — hard pre-flight.** Before claiming any OpenSpec change complete (or "harness green/aligned/fixed"), run the gate and report real output. Preferred: `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`, also `make loop-trigger`) — all eight stages. **HOW TO RUN: long-running `make` targets (`run-agentics`, `build-app`, `test-app`, `loop-harness`, `loop-e2e`, `deliver-change`, `phase7-archive`, `release-flow`) MUST be launched via `terminal(background=true)` — that call executes on the REAL HOST (`/home/asimov/repository/git/projects/obsidian-timestamp-utility`), where `make`/`docker`/rootless `nerdctl`/live Ollama all live. The foreground sandbox (`/workspace`) has NO docker/nerdctl and will say `docker: command not found` — that is EXPECTED and is NOT a blocker; the host has it.** The host provides rootless `nerdctl` AND a live Ollama (host-networked, so `127.0.0.1:11434` reaches it — B19), so `loop-unit-real` and `loop-e2e` are EXPECTED to RUN, not skip. Only STILL run the hermetic gates `make loop-collect` + `make loop-ts-floor` + `make loop-unit` (no external dep) when a stage truly cannot finish in the session; they MUST be green before any "done". Report honestly (PASS/SKIP/FAIL, failing stage named); never claim green if `loop-unit`/`loop-collect` is red; **never claim "can't run from here" — the host runs `make` for you.** Fix root cause and re-run. (B4/B14: no git commit/push from the gate.) |
+| **B26** | **AGENT MAY COMMIT/MERGE ITS OWN CHANGES on a non‑main branch when the PRE‑COMMIT HOOK PASSES.** Permitted to `git commit` (and `git merge`/`git cherry‑pick`) its OWN work‑in‑progress on a feature branch so it can iterate productively. Bounded by: (1) branch guard — current branch MUST NOT be `main`/`origin/main`/protected; (2) hook guard — `git-hooks/pre-commit` (gitleaks + trailing‑whitespace) MUST pass; the agent commits only via the normal `git commit` path, NEVER `--no-verify`. Still forbidden (human‑only): `git push` (B14), `make squash-commits`, `git rebase -i` squash/fixup, `git reset --soft` collapse (B25). Adds commit/merge latitude on feature branches; does NOT lift no‑push/no‑squash/no‑force. (B21–B25 are documented in `AGENTS.md`.) |
 
 ---
 
@@ -714,12 +720,19 @@ Follow the §5.2 self‑correct loop:
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>` → `openspec new change`, per B15) + tasks, validate it, and
-  start the loop — according to the **per-channel trigger**:
+  **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree `feat/<name>`,
+  scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives on green,
+  finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing `feat/<name>`
+  as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER touched
+  (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -737,7 +750,7 @@ This file, `AGENTS.md`, and `hermes/skills/openspec-loop-harness.md` are the **s
 truth**. When you change a behaviour, constraint, command, or pitfall in **any one** of them,
 mirror it in the **other two** before considering the change done:
 
-- Repo authority: `AGENTS.md` (phase flow + B1–B25 summary).
+- Repo authority: `AGENTS.md` (phase flow + B1–B26 summary).
 - Skill mirror: `hermes/skills/openspec-loop-harness.md` (operator‑level detail + pitfalls).
 - This guide: `docs/openspec-engineering-loop-harness.md` (human‑readable technical reference).
 

--- a/tests/fixtures/check_docs_sync/drift_stage_removed/hermes/skills/openspec-loop-harness.md
+++ b/tests/fixtures/check_docs_sync/drift_stage_removed/hermes/skills/openspec-loop-harness.md
@@ -24,7 +24,7 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
   walk), (3) **diagnose & correct by fixing the SOURCE OF TRUTH not the symptom** (edit the spec,
   restore, re-run — never hand-edit generated TS, B11; each pass a *different* tweak), and
   (4) **terminate** (bounded ~5 attempts, then escalate to fixing the Python floor B13). Durable
-  invariants B1–B25 are the loop's "laws of physics" that never regress on any pass.
+  invariants B1–B26 are the loop's "laws of physics" that never regress on any pass.
 - **How they fit:** the harness is the **floor** (nothing worse can be written); the loop is the
   **ratchet** (each pass only moves toward green, invariants never slip). Full write-up:
   `docs/openspec-engineering-loop-harness.md` §0.
@@ -181,12 +181,19 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>` → `openspec new change`, per B15) + tasks, validate it, and
-  start the loop — according to the **per-channel trigger**:
+  **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree `feat/<name>`,
+  scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives on green,
+  finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing `feat/<name>`
+  as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER touched
+  (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -196,7 +203,7 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
   `docs/openspec-engineering-loop-harness.md` (B8). The reusable directive is the Hermes skill
   `request-to-openspec` (loaded at request entry).
 
-## Durable agent behaviours (B1–B25) — MUST always hold, never regress
+## Durable agent behaviours (B1–B26) — MUST always hold, never regress
 
 These are standing rules for the agent (also in `AGENTS.md`). They are enforced by
 `make phase7-archive` and the persistent harness
@@ -269,7 +276,7 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
   different behaviour. The full B8 sync set (enforced by `make check-docs-sync`, the FINAL loop
   stage) also includes `Makefile`, `docs/openspec-engineering-loop-harness.md`, and
   `scripts/run-loop-harness.sh` — all MUST agree on the 8-stage order + final `check-docs-sync`,
-  the `loop-ts-floor` guard, and the B1–B25 range; a drift there fails the loop.
+  the `loop-ts-floor` guard, and the B1–B26 range; a drift there fails the loop.
 - **(B9) Rootless nerdctl bind-mount permissions (READ + WRITE).** Execution is docker compose
   with **rootless nerdctl**, which remaps the container uid (1000) to the host **`other`** class.
   Every file/dir the container must READ (the whole repo, since compose mounts `..:/project`)
@@ -323,15 +330,17 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
   `_expected_contract_for_change`) only reads the spec contract and merges it deterministically —
   it must never author TS bodies. Hand-editing generated TS is forbidden because it bypasses the
   deterministic merge floor and desyncs the spec from the code.
-- **(B12) Delivery gap — verified worktree TS MUST reach the active branch.** The pipeline
+- **(B12) Delivery gap — verified worktree TS MUST reach the target branch as the PR.** The pipeline
   generates + verifies TS **inside a git worktree** (`worktrees/<name>`, branch `feat/<name>`).
   The harness MUST NOT stop there: a feature green only in the worktree that never lands on its
-  target branch is a failed delivery. After `build-app`+`test-app` are green, the agent MUST pull
-  the verified `src/main.ts` + `src/__tests__/main.test.ts` back onto the **current branch's
-  working tree** (e.g. `make deliver-change CHANGE=<name>` — a file copy, NOT a commit; B4 holds).
-  Never declare a change "done" while its generated TS still lives only in the worktree. (AGENTS.md
-  Phase 5's "old TS remains until you deliberately merge the worktree" previously let verified
-  code die in the worktree — B12 overrides that silence.)
+  target branch is a failed delivery. The agent delivers by **pushing the worktree branch as the PR**
+  (`git push origin feat/<name>`, or `make openspec-flow NAME=<name> PUSH=1`) — it MUST NOT copy
+  generated TS back into the parent working tree (that would re-introduce pollution; ALL artifacts
+  stay in the worktree by design — see `openspec-change-worktree-flow`). Corrections redeliver via
+  `make openspec-redeliver NAME=<name>` (`git push --force-with-lease` to the SAME PR branch only;
+  never `main`). Never declare a change "done" while its worktree branch has not been delivered.
+  (Earlier wording told the agent to `make deliver-change` — a file copy onto the current branch —
+  which conflicts with the worktree-confinement invariant; this override supersedes it.)
 - **(B13) Python *floor* defects are fixed directly, not via spec round-trips.** B11's spec-first
   rule applies when the GENERATED TS/test is wrong. If the defect is in the *deterministic floor*
   itself (e.g. the integrator skips injecting the spec contract when the LLM already emitted a same-
@@ -377,7 +386,7 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
       collection guard — fail fast on dangling imports, rule 4 below) → `loop-ts-floor` (STRICT TS
       test/command floor — FAIL if the current branch's `describe`/leaf `it`/`test`/jest-collected/
       `addCommand` counts drop below `origin/main`; the silent feature/test-removal guard) → `loop-unit`
-      (mocked, hermetic) → `loop-unit-real` (REAL agent unit tests on live Ollama, no mocks) 
+      (mocked, hermetic) → `loop-unit-real` (REAL agent unit tests on live Ollama, no mocks)
       (the 3 standing B1/B3 e2e gates) → `loop-integration` (broad agentic integration suite) →
       `loop-build-app` → `loop-test-app`. Each stage fails the whole run (no silent green). Rules for the
       integration tests:
@@ -431,7 +440,7 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
  `127.0.0.1:11434` reaches the live Ollama on the docker host), so they must RUN (not skip) — fix
  root resolution, never add an OLLAMA skip guard. (Closed the gap where `test_greetings_contract_unit.py` + `test_slim_refactor_invariants_unit.py` failed post-archive, and where `test_ticket20/ticket22/greetings` e2e errored on `FileNotFoundError: 'openspec'` due to `/app` root resolution.)
     - **(B20) NEVER declare a change "done" without running the loop gate first — hard pre-flight.** Before claiming any OpenSpec change complete (or "harness green/aligned/fixed"), run the gate and report real output:
-      1. **Preferred:** `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`) — all eight stages: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real`  → `loop-integration` → `loop-build-app` → `loop-test-app`. Also `make loop-trigger`.
+      1. **Preferred:** `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`) — all stages: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real`  → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync`. Also `make loop-trigger`.
       2. **If full `make loop-harness` can't finish** (live Ollama absent for `loop-e2e`/`loop-unit-real`, or npm build times out), STILL run the hermetic gates `make loop-collect` + `make loop-ts-floor` + `make loop-unit` (no external dep) — they MUST be green before any "done".
       3. **Report honestly:** actual per-stage PASS/SKIP/FAIL with the failing stage named. Never say "done/green" if `loop-unit`/`loop-collect` is red; fix the root cause and re-run. Rationale: the agent previously finished work (incl. AGENTS.md/skill edits) WITHOUT running the gate, leaving `make loop-unit` red. B20 makes the gate mandatory so regressions are caught before "done". (B4/B14: no git commit/push from the gate.)
     - **(B21) HITL is OPT-IN and loop-excluded — never a blocking prompt in automation.** `HITLNode`
@@ -498,6 +507,14 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
       graph. The agent MAY commit (B23) and merge/cherry-pick, but must NOT rewrite/squash existing
       history. If history is messy (leaked throwaway commits), FLAG it for the human and ask — do not
       decide unilaterally. `make squash-commits` is human-triggered only. B8: mirror in AGENTS.md.
+    - **(B26) AGENT MAY COMMIT/MERGE ITS OWN CHANGES on a non-main branch when the PRE-COMMIT HOOK
+      PASSES.** Permitted to `git commit` (and `git merge`/`git cherry-pick`) its OWN work-in-progress
+      on a feature branch so it can iterate productively. Bounded by: (1) branch guard — current
+      branch MUST NOT be `main`/`origin/main`/protected; (2) hook guard — `git-hooks/pre-commit`
+      (gitleaks + trailing-whitespace) MUST pass; the agent commits only via the normal `git commit`
+      path, NEVER `--no-verify`. Still forbidden (human-only): `git push` (B14), `make squash-commits`,
+      `git rebase -i` squash/fixup, `git reset --soft` collapse (B25). Adds commit/merge latitude on
+      feature branches; does NOT lift no-push/no-squash/no-force. B8: mirror in AGENTS.md + harness doc.
     ## Plan-B merge refactor (integrator-merge-refactor)
 
 - **Imports:** inject new `import` lines at the top (after the last existing top-level import).

--- a/tests/fixtures/check_docs_sync/in_sync/AGENTS.md
+++ b/tests/fixtures/check_docs_sync/in_sync/AGENTS.md
@@ -69,7 +69,7 @@ every spec requirement/scenario); (3) **diagnose & correct by fixing the SOURCE 
 symptom** — edit the OpenSpec spec/contract, restore the generated files to a clean baseline, and
 re-run; NEVER hand-edit generated TS (B11), and each pass must try a *different* correction; and
 (4) **terminate** — a bounded ~5 attempts with a clear escalation (fix the Python floor as a last
-resort, B13). The durable behaviours B1–B25 are the loop's "laws of physics" — invariants that
+resort, B13). The durable behaviours B1–B26 are the loop's "laws of physics" — invariants that
 never regress on any pass (permanent e2e B1–B6, no-commit/no-push gate B4/B14, delivery step B12).
 
 **How they fit:** the harness is the **floor** (nothing worse than the contract can ever be
@@ -398,7 +398,7 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
  coordinate `127.0.0.1:11434` reaches the live Ollama on the docker host), so they must RUN (not
  skip) — root resolution is the actual bug to fix, not a skip guard.
   - **(B20) NEVER declare a change "done" without running the loop gate first — this is a hard pre-flight, not optional.** Before reporting any OpenSpec change as complete (or before claiming "the harness is green / aligned / fixed"), the agent MUST execute the loop gate and report its real output:
-      1. **Preferred:** run `bash scripts/run-loop-harness.sh` (the loop-harness runner — it streams each stage's container/pytest/jest output to the terminal LIVE, prints a start banner + heartbeat on quiet stages, and ends with a per-stage PASS/FAIL/timeout summary; it wraps `make <stage>` in `setsid script … | tee` so nerdctl's forced `--tty` gets a console without deadlocking under an interactive shell). It runs all eight stages in order: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app`. (The standalone `make test-agents-*` / `make run-agentics` commands also self-provide a console via the Makefile `$(call docker_run, …)` helper, which uses `script` only when stdout is not a tty.)
+      1. **Preferred:** run `bash scripts/run-loop-harness.sh` (the loop-harness runner — it streams each stage's container/pytest/jest output to the terminal LIVE, prints a start banner + heartbeat on quiet stages, and ends with a per-stage PASS/FAIL/timeout summary; it wraps `make <stage>` in `setsid script … | tee` so nerdctl's forced `--tty` gets a console without deadlocking under an interactive shell). It runs all stages in order: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync`. (The standalone `make test-agents-*` / `make run-agentics` commands also self-provide a console via the Makefile `$(call docker_run, …)` helper, which uses `script` only when stdout is not a tty.)
          **HOW TO RUN (never make excuses):** long-running `make` targets (`run-agentics`, `build-app`, `test-app`, `loop-harness`, `loop-e2e`, `deliver-change`, `phase7-archive`, `release-flow`) MUST be launched via `terminal(background=true)` — that call executes on the **REAL HOST** (`/home/asimov/repository/git/projects/obsidian-timestamp-utility`), where `make`/`docker`/rootless `nerdctl`/live Ollama all live. The foreground sandbox (`/workspace`) has NO docker/nerdctl and will print `docker: command not found` — that is EXPECTED and is NOT a blocker; the host has it. **Never say "can't run from here" / "environment absent" — the host runs `make` for you.** Drive verification through `make` with REAL output, always.
       2. **If the full `make loop-harness` cannot complete in the session** (e.g. an explicit
          timeout, or a stage is deliberately disabled via env), the agent MUST STILL run the
@@ -437,8 +437,11 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
          sections AND the bump PART.
        - **`make lint-commits`** — run `commitlint` over the squashed range / HEAD; the changelog lint
          gate (fail-closed on any invalid message).
-       - **`make install-git-hooks`** — wire `git-hooks/commit-msg` into `.git/hooks` so every
-         manual `git commit` is linted by commitlint (per-commit Conventional-Commit gate).
+       - **`make install-git-hooks`** — wire `git-hooks/commit-msg` (per-commit Conventional-Commit
+         lint) and `git-hooks/pre-commit` (trailing-whitespace auto-fix) into `.git/hooks` so every
+         manual `git commit` is linted. The pre-commit hook only strips trailing whitespace from
+         staged text files and **never exits non-zero**, so it is inert under the loop (which performs
+         no `git commit`).
        - **`make changelog`** — regenerate sectioned `CHANGELOG.md` (git_chglog; one `## <version>`
          section per git tag, so a local `v<version>` tag after bump yields a viewable new section).
        - **`make release-notes`** — refresh the README release-notes block.
@@ -543,6 +546,26 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
        3. `make squash-commits` is a HUMAN-TRIGGERED command only. The agent may mention it as an
           option, but must not execute it unless the human approved it for the current branch.
      B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md`.
+  - **(B26) AGENT MAY COMMIT/MERGE ITS OWN CHANGES on a non-main branch when the PRE-COMMIT HOOK
+     PASSES.** The agent is permitted to `git commit` (and `git merge`/`git cherry-pick`) its OWN
+     work-in-progress — e.g. landing this feature branch's OpenSpec change, scripts, Makefile, and
+     doc-sync edits — so it can iterate productively without waiting for a human to commit each
+     step. The permission is bounded by two hard conditions:
+       1. **Branch guard:** the current branch MUST NOT be `main` or `origin/main` (nor any other
+          protected branch). On `main`, B4/B14/B25 still forbid the agent from committing/pushing on
+          its own — a human triggers that.
+       2. **Hook guard:** the `git-hooks/pre-commit` (gitleaks secret scan + trailing-whitespace) MUST
+          pass. The agent commits ONLY through the normal `git commit` path so the hook runs; it
+          NEVER uses `--no-verify`. If the hook fails, the commit is blocked and the agent fixes the
+          underlying issue (or stops) rather than bypassing the guard.
+       3. **Still forbidden (human-only):** `git push` (B14), `make squash-commits`, `git rebase -i`
+          with squash/fixup, and `git reset --soft` + collapse (B25). This behaviour ADDS commit/merge
+          latitude on feature branches; it does NOT lift the no-push / no-squash / no-force gates.
+       4. Commits should be atomic and conventionally-scoped (the `git-hooks/commit-msg` lint applies).
+          The agent keeps `tasks.md` ticked as work is verified (B16) and re-runs `make check-docs-sync`
+          when it edits a sync doc.
+     B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md` and
+     `docs/openspec-engineering-loop-harness.md`.
   - **(B7.1) The deterministic floor runs in EVERY mode (incl. fast).** `route_hitl` in
     `composable_workflows.py` previously returned `output_result` when `TEST_FAST_MODE=1` (set by
     `tests/integration/conftest.py` to skip the npm-test phase), which bypassed `integration_testing`
@@ -600,17 +623,18 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
          code lingers and the next run starts clean).
       3. **Re-run** `make run-agentics` to regenerate from the corrected spec, then
          `make build-app` + `make test-app` until green.
-  - **(B12) Delivery gap — the verified worktree TS MUST reach the active branch.** The
-    agentic pipeline generates + verifies TS **inside a git worktree** (`worktrees/<name>`,
-    branch `feat/<name>`). The harness MUST NOT stop there: a feature that is green only in the
-    worktree and never lands on the branch it targets is a failed delivery. After `make
-    build-app` + `make test-app` are green in/for the worktree, the agent MUST pull the verified
-    `src/main.ts` + `src/__tests__/main.test.ts` back onto the **current branch's working tree**
-    (e.g. `make deliver-change CHANGE=<name>`, which copies the worktree files into the repo tree).
-    This is a file copy only — it does NOT commit/push (B4); committing remains a deliberate human
-    step. The agent must NEVER declare a change "done" while its generated TS still lives only in
-    the worktree. (Pitfall: AGENTS.md Phase 5's "the old TS remains until you deliberately merge
-    the worktree" previously let verified code die in the worktree — B12 overrides that silence.)
+  - **(B12) Delivery gap — verified worktree TS MUST reach the target branch as the PR.** The
+    pipeline generates + verifies TS **inside a git worktree** (`worktrees/<name>`, branch
+    `feat/<name>`). The harness MUST NOT stop there: a feature green only in the worktree that never
+    lands on its target branch is a failed delivery. The agent delivers by **pushing the worktree
+    branch as the PR** (`git push origin feat/<name>`, or `make openspec-flow NAME=<name> PUSH=1`) —
+    it MUST NOT copy generated TS back into the parent working tree (that would re-introduce
+    pollution; ALL artifacts stay in the worktree by design — see `openspec-change-worktree-flow`).
+    Corrections redeliver via `make openspec-redeliver NAME=<name>` (`git push --force-with-lease`
+    to the SAME PR branch only; never `main`). Never declare a change "done" while its worktree
+    branch (`feat/<name>`) has not been delivered. (Earlier wording told the agent to
+    `make deliver-change` — a file copy onto the current branch — which conflicts with the
+    worktree-confinement invariant; this override supersedes it.)
     **Bounded self-correct loop (≈5 e2e attempts):** repeat the fix-spec → restore → re-run
     sequence for up to ~5 full e2e runs (`make run-agentics` with that spec file). Each failed
     attempt MUST first try a **different adjustment to the spec/contract file** (tasks.md
@@ -635,8 +659,8 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
   stage order, the `loop-ts-floor` guard, or the B-behaviour range:
   1. **`Makefile`** — the executable gates + canonical stage-order comment; `make loop-harness`
      runs `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e`
-     → `loop-integration` → `loop-build-app` → `loop-test-app` → `check-docs-sync` (final).
-  2. **`AGENTS.md`** — this file: the authoritative narrative + the B1–B25 durable behaviours.
+           → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync` (final).
+  2. **`AGENTS.md`** — this file: the authoritative narrative + the B1–B26 durable behaviours.
   3. **`hermes/skills/openspec-loop-harness.md`** — the loadable skill mirror of AGENTS.md.
   4. **`docs/openspec-engineering-loop-harness.md`** — the human-readable technical reference
      (named by B8 itself as authoritative; MUST be kept in the sync set, not treated as a 4th
@@ -648,7 +672,7 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
      marked `@pytest.mark.e2e`) — the runtime proof the loop works.
   Before claiming "the loop is green / aligned", run `make check-docs-sync` (the final loop stage)
   and confirm it PASSES: all sync docs agree on the 8-stage order + final `check-docs-sync`, the
-  `loop-ts-floor` guard, the B1–B25 behaviours, and the live-test skip rule (`OLLAMA_HOST` only,
+  `loop-ts-floor` guard, the B1–B26 behaviours, and the live-test skip rule (`OLLAMA_HOST` only,
   not `GITHUB_TOKEN`). A change is NOT done while any of the sync docs disagree.
 - The harness is the OpenSpec change: `proposal.md` defines *why*, `specs/**` defines *what must
   hold*, `tasks.md` defines *the steps to run*. The agentic pipeline turns tasks into code+tests.
@@ -678,12 +702,19 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>`, which shells out to `openspec new change` per B15) +
-  tasks, validate it, and start the loop — according to the **per-channel trigger**:
+  tasks, validate it, and **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree
+  `feat/<name>`, scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives
+  on green, finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing
+  `feat/<name>` as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER
+  touched (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -692,3 +723,43 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
   `make openspec-new` / `openspec new change`; do NOT limit itself to kanban tooling.  The reusable directive lives in the Hermes skill
   `request-to-openspec` (loaded at request entry). Mirrored in `openspec-loop-harness.md` and
   `docs/openspec-engineering-loop-harness.md` (B8).
+
+---
+
+## Secret scanning (gitleaks)
+
+The broken TruffleHog GitHub Action was replaced by **gitleaks** (the de-facto open-source scanner).
+The actual secret **scan** lives in the pre-commit hook + CI (NOT a loop-harness stage); the
+secret-scanner's own **pytest suite** runs as a loop-harness stage (`loop-secret-scan-tests`).
+
+- **Engine:** `scripts/secret_scanner.py` delegates 100% of detection to gitleaks — no homemade
+  regex/entropy detector. It is the LOCAL fail-closed **hook** guard (dev-side), not a loop command.
+- **Config:** `.gitleaks.toml` uses `[extend] useDefault = true` plus repo-local `allowlist` entries
+  for test fixtures, docs, dependency/build caches (`.venv`, `node_modules`, `__pycache__`, and so on),
+  and `.env`/`.git`. **Do NOT replace `useDefault = true` with an empty `path`** — that silently
+  disables the entire default ruleset.
+- **Scan lives in the hook + CI (NOT the loop):** the gitleaks repo scan runs in `git-hooks/pre-commit`
+  (`python3 scripts/secret_scanner.py --staged`) and `git-hooks/commit-msg` (`--message-file`), and in
+  CI (`.github/workflows/trufflehog.yml`, `gitleaks/gitleaks-action@v2`). A detected secret blocks the
+  commit / fails CI. A standalone `make loop-secret-scan` target exists for on-demand scans but is NOT
+  a loop stage (the loop must not re-scan the tree — the hook already guards every commit).
+- **Loop stage = the scanner's own tests (containerized, B9):** `make loop-secret-scan-tests` builds
+  `secret-scan-tests-image` (real gitleaks + pytest) and runs `tests/test_secret_scanner*.py` **inside
+  the `gitleaks-tests` compose container** (`docker-compose-files/gitleaks-tests.yaml`), exercising the
+  REAL gitleaks binary (no mocks on detection). It sits between `loop-test-app` and `check-docs-sync`
+  in the canonical stage order. This verifies the scanner's detection logic itself every loop run.
+- **No duplicate scan commands:** the Makefile has exactly ONE on-demand scan target (`loop-secret-scan`,
+  alias `check-secrets`); it does NOT shell out to `python3` or a bare host `gitleaks` binary — docker
+  compose only, like every other harness gate. `make secret-scan-image` / `make secret-scan-tests-image`
+  build images; `make test-secret-scanner` runs the pytest suites on the host. `loop-secret-scan-tests`
+  is the canonical loop entry that runs the suite containerized.
+- **Hooks (fail-closed, local dev guard):** `git-hooks/pre-commit` runs `python3 scripts/secret_scanner.py --staged`;
+  `git-hooks/commit-msg` runs `python3 scripts/secret_scanner.py --message-file`. A detected secret
+  rejects the commit. Installed via `make install-git-hooks`.
+- **CI:** `.github/workflows/trufflehog.yml` is a gitleaks workflow (`gitleaks/gitleaks-action@v2`,
+  `fetch-depth: 0`, `GITLEAKS_CONFIG=.gitleaks.toml`).
+- **Tests:** `tests/test_secret_scanner.py` (hermetic unit) + `tests/test_secret_scanner_integration.py`
+  (real gitleaks binary, no mocks on detection). Run with `make test-secret-scanner` (host) or via the
+  loop stage `loop-secret-scan-tests` (containerized).
+- **Credential hygiene:** never put real API keys/tokens in source or tests. Use documented example
+  shapes (e.g. `AKIA…EXAMPLE`, `xoxb-…`) or `[REDACTED]`.

--- a/tests/fixtures/check_docs_sync/in_sync/docs/openspec-engineering-loop-harness.md
+++ b/tests/fixtures/check_docs_sync/in_sync/docs/openspec-engineering-loop-harness.md
@@ -8,7 +8,7 @@
 > 2. **Harness engineering** — the Python "agentics" pipeline (`agents/agentics/`) and
 >    the deterministic merge floor that writes your `src/main.ts` / `src/__tests__/main.test.ts`.
 > 3. **Loop engineering** — the bounded self‑correcting build→test→fix loop and the
->    durable behaviours **B1–B25** that the loop must always honour.
+>    durable behaviours **B1–B26** that the loop must always honour.
 >
 > It also documents the **file structure**, every file that creates the harness's
 > behaviour, and a **how‑to‑use** walkthrough for authoring a new feature.
@@ -21,7 +21,7 @@ at repo root, the previous `docs/openspec-loop-harness-guide.md`) are historical
 ## 0. Fundamentals — what "harness" and "loop" engineering mean
 
 Before the technical detail, understand the two disciplines this whole system is built on.
-Everything below (OpenSpec, the Python pipeline, the Makefile, B1–B25) is just a concrete
+Everything below (OpenSpec, the Python pipeline, the Makefile, B1–B26) is just a concrete
 implementation of these two ideas. If you internalise this section, the rest of the document
 reads as "here is *how* we do harness + loop engineering in this repo."
 
@@ -91,7 +91,7 @@ A well‑engineered loop has four parts:
    a loop with no escalation hides real defects.
 
 The loop is also where **durability** lives: the invariants that must hold on *every* pass
-(B1–B25) — a permanent regression e2e that outlives every feature (B1–B6), the no‑commit/no‑push
+(B1–B26) — a permanent regression e2e that outlives every feature (B1–B6), the no‑commit/no‑push
 gate (B4/B14), the delivery step that moves verified code out of the worktree onto the branch
 (B12). These are the loop's "laws of physics": conditions that never regress no matter how many
 times you go round.
@@ -105,7 +105,7 @@ gate is green, then stop."
 | Discipline | Job | Answers the question | In this repo |
 |-----------|-----|----------------------|--------------|
 | **Harness engineering** | *Constrain* the generator into a verifiable shape | "How do I make one generation trustworthy?" | OpenSpec contract as source of truth + `CodeIntegratorAgent` deterministic merge floor + omission guard + B9 perms + git‑HEAD restore |
-| **Loop engineering** | *Correct* the generator across attempts until an objective gate passes | "How do I make the system converge on correct, and know when to stop?" | `make build-app`/`make test-app` gate + spec‑first self‑correct loop (bounded ~5) + durable behaviours B1–B25 + delivery step B12 |
+| **Loop engineering** | *Correct* the generator across attempts until an objective gate passes | "How do I make the system converge on correct, and know when to stop?" | `make build-app`/`make test-app` gate + spec‑first self‑correct loop (bounded ~5) + durable behaviours B1–B26 + delivery step B12 |
 
 The harness is the **floor** (nothing worse than this can be written); the loop is the **ratchet**
 (each pass can only move toward green, and the invariants never slip back). The rest of this
@@ -148,7 +148,7 @@ Three non‑negotiable principles:
 
 ```
 obsidian-timestamp-utility/
-├── AGENTS.md                         # Repo‑level authority: phase flow + B1–B25 summary
+├── AGENTS.md                         # Repo‑level authority: phase flow + B1–B26 summary
 ├── Makefile                          # ALL execution entry points (docker compose only, no Dagger)
 ├── docker-compose-files/
 │   ├── agents.yaml                   # agentics / unit‑test‑agents / integration‑test‑agents services
@@ -547,18 +547,23 @@ if invoking docker compose outside the Makefile. World‑readable on a private r
 
 `make run-agentics` generates + verifies TS **inside a worktree**. The harness must NOT stop
 there: a feature green only in the worktree that never lands on its target branch is a failed
-delivery. After `build-app`+`test-app` are green, pull the verified files back onto the current
-branch's working tree:
+delivery. Deliver it by **pushing the worktree branch as the PR** — NOT by copying files back into
+the parent working tree (that would re-introduce pollution; ALL artifacts stay in the worktree by
+design — see `openspec-change-worktree-flow`):
 
 ```bash
-make deliver-change CHANGE=<name>     # copies worktree src/main.ts + main.test.ts → repo (file copy, NO commit)
+make openspec-flow NAME=<name> PUSH=1     # creates worktree, archives on green, finalizes, pushes feat/<name> as PR
+# corrections after a pass:
+make openspec-redeliver NAME=<name>        # re-enters worktree, re-squashes, force-pushes to the SAME PR branch (--force-with-lease, never main)
 ```
 
-Never declare a change "done" while its generated TS still lives only in the worktree.
+Never declare a change "done" while its worktree branch (`feat/<name>`) has not been delivered.
+(The earlier `make deliver-change` file-copy directive conflicts with the worktree-confinement
+invariant and is superseded by this PR-push model.)
 
 ---
 
-## 6. Durable behaviours B1–B25 (must always hold, never regress)
+## 6. Durable behaviours B1–B26 (must always hold, never regress)
 
 | ID | Behaviour |
 |----|-----------|
@@ -573,14 +578,15 @@ Never declare a change "done" while its generated TS still lives only in the wor
 | **B9** | Rootless nerdctl bind‑mount permissions (READ+WRITE). Whole repo world‑readable; container write targets world‑writable. Enforced by the `b9-perms` Makefile prerequisite. |
 | **B10** | **NO hard‑coded generated TS/test code in Python** — only contract‑steered. Generated TS bodies live *only* in the change's `tasks.md`/`spec.md` markers; Python only parses + merges + injects verbatim. |
 | **B11** | On generated‑TS failure: **fix the SPEC, then restore, then re‑run** — never edit TS by hand. Bounded ~5‑attempt self‑correct loop; only then may Python floor code be touched as last resort. |
-| **B12** | Delivery gap — verified worktree TS MUST reach the active branch (`make deliver-change`). Never declare done while TS lives only in the worktree. |
+| **B12** | Delivery gap — verified worktree TS MUST reach the target branch as the PR (`make openspec-flow NAME=<name> PUSH=1` → `git push feat/<name>`; corrections via `make openspec-redeliver` force-push to the SAME PR branch). NEVER a file copy into the parent working tree (worktree-confinement invariant). Never declare done while the worktree branch is undelivered. |
 | **B13** | Python *floor* defects are fixed directly, not via spec round‑trips. If the defect is in the deterministic floor itself, fix `CodeIntegratorAgent` — that is the correct spec‑steered fix; only the *merge logic* is corrected, the contract TS body still comes from the spec. |
 | **B14** | Commit/push gating for *new* code (human‑only, behaviour‑scoped). Code is committed ONLY if NEW; pushed ONLY if that new code is part of a behaviour. Floor/integrator Python fixes MAY be committed (and pushed only when part of a committed behaviour) **once**: `build-app`=0, `test-app`=0, passing‑test count **>** previous run, and all OpenSpec checks clean. Rule of thumb: commit only if new AND build works AND tests pass > last run AND OpenSpec clean; push only if that commit is the behaviour landing. **Never squash/rebase/force‑push.** |
 | **B15** | **GitHub issue → local OpenSpec change via the OpenSpec CLI (seed‑then‑generate).** When a change is sourced from a GitHub issue, the agentic code MUST turn it into a local OpenSpec change by **shelling out to `openspec new change ticket<N>`** (the same CLI step a human runs) — never hand‑writing the directory, never a raw `Path.write_text` for the directory shape. `fetch_issue_agent.py` calls `openspec_loader.create_change_from_issue(url, title, body)` after the fetch; that scaffolds via the CLI, fills `proposal.md`/`specs/<cap>/spec.md`/`tasks.md` from the issue, and re‑points generation to `openspec:ticket<N>` so the rest of the loop runs offline. The change name is derived deterministically from the issue URL (`.../issues/20` → `ticket20`), so re‑runs are idempotent. The seeded `openspec/changes/ticket<N>/` is a RUNTIME artifact and MUST NOT be committed (extends B4); `ticket20`/`ticket22` e2e tests generate + clean it up in `finally`. Keeps B10 honest: the exact `openspec new change` a human runs is the one the pipeline runs. |
 | **B16** | **Task‑completion discipline — tick as you verify, never leave open tasks, archive gate fails closed.** `make phase7-archive` runs `openspec_loader.assert_no_open_tasks` BEFORE `openspec archive` and refuses (non‑zero exit, no spec merge) if any `- [ ]` task remains. A change is "done" only when all tasks are ticked AND verified AND archived. `make loop-tasks` lists open/done per change so the backlog is never invisible. |
-| **B17** | **Integration suite is a mandatory loop phase; no dead tests; live tests skip cleanly.** `make loop-harness` runs EIGHT loop stages plus a FINAL B8 doc-sync gate: a collection guard (gate 0), a strict TS test/command floor (gate 0.5), followed by six gates (1–6): `loop-collect` (hermetic collection guard) → `loop-ts-floor` (STRICT TS test/command floor — FAIL if the current branch's `describe`/leaf `it`/`test`/jest-collected/`addCommand` counts drop below `origin/main`) → `loop-unit` (mocked, hermetic) → `loop-unit-real` (REAL agent unit tests on live Ollama, no mocks) → `loop-e2e` (B1/B3 e2e) → `loop-integration` (broad suite) → `loop-build-app` → `loop-test-app`, then `check-docs-sync` (FINAL B8 gate — FAIL if any sync doc drifts on stage order / `loop-ts-floor` / B-range). No dead duplicates; live tests `skipif` cleanly on `OLLAMA_HOST`. |
+| **B17** | **Integration suite is a mandatory loop phase; no dead tests; live tests skip cleanly.** `make loop-harness` runs EIGHT loop stages plus a FINAL B8 doc-sync gate: a collection guard (gate 0), a strict TS test/command floor (gate 0.5), followed by six gates (1–6): `loop-collect` (hermetic collection guard) → `loop-ts-floor` (STRICT TS test/command floor — FAIL if the current branch's `describe`/leaf `it`/`test`/jest-collected/`addCommand` counts drop below `origin/main`) → `loop-unit` (mocked, hermetic) → `loop-unit-real` (REAL agent unit tests on live Ollama, no mocks) → `loop-e2e` (B1/B3 e2e) → `loop-integration` (broad suite) → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` (secret-scanner pytest suite, containerized, real gitleaks, fail-closed; the actual gitleaks tree-scan lives in the pre-commit hook + CI, not the loop), then `check-docs-sync` (FINAL B8 gate — FAIL if any sync doc drifts on stage order / `loop-ts-floor` / B-range). No dead duplicates; live tests `skipif` cleanly on `OLLAMA_HOST`. |
 | **B18** | **Run the agents' REAL unit tests, not only the mocked ones.** The loop MUST execute BOTH the hermetic mocked unit run (`loop-unit` → `test-agents-unit-mock`) AND the real, non‑mocked agent unit run (`loop-unit-real` → `test-agents-unit`, live Ollama) as gates 1 and 2. Reporting "agent tests green" after ONLY the mocked run is INCOMPLETE. `test-agents-unit` MUST be run when Ollama is reachable and its result reported alongside — not instead of — the mocked run. If Ollama is unreachable, `loop-unit-real` SKIPS (must not error) but the agent MUST state the real unit gate did not run. |
 | **B20** | **NEVER declare a change "done" without running the loop gate first — hard pre-flight.** Before claiming any OpenSpec change complete (or "harness green/aligned/fixed"), run the gate and report real output. Preferred: `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`, also `make loop-trigger`) — all eight stages. **HOW TO RUN: long-running `make` targets (`run-agentics`, `build-app`, `test-app`, `loop-harness`, `loop-e2e`, `deliver-change`, `phase7-archive`, `release-flow`) MUST be launched via `terminal(background=true)` — that call executes on the REAL HOST (`/home/asimov/repository/git/projects/obsidian-timestamp-utility`), where `make`/`docker`/rootless `nerdctl`/live Ollama all live. The foreground sandbox (`/workspace`) has NO docker/nerdctl and will say `docker: command not found` — that is EXPECTED and is NOT a blocker; the host has it.** The host provides rootless `nerdctl` AND a live Ollama (host-networked, so `127.0.0.1:11434` reaches it — B19), so `loop-unit-real` and `loop-e2e` are EXPECTED to RUN, not skip. Only STILL run the hermetic gates `make loop-collect` + `make loop-ts-floor` + `make loop-unit` (no external dep) when a stage truly cannot finish in the session; they MUST be green before any "done". Report honestly (PASS/SKIP/FAIL, failing stage named); never claim green if `loop-unit`/`loop-collect` is red; **never claim "can't run from here" — the host runs `make` for you.** Fix root cause and re-run. (B4/B14: no git commit/push from the gate.) |
+| **B26** | **AGENT MAY COMMIT/MERGE ITS OWN CHANGES on a non‑main branch when the PRE‑COMMIT HOOK PASSES.** Permitted to `git commit` (and `git merge`/`git cherry‑pick`) its OWN work‑in‑progress on a feature branch so it can iterate productively. Bounded by: (1) branch guard — current branch MUST NOT be `main`/`origin/main`/protected; (2) hook guard — `git-hooks/pre-commit` (gitleaks + trailing‑whitespace) MUST pass; the agent commits only via the normal `git commit` path, NEVER `--no-verify`. Still forbidden (human‑only): `git push` (B14), `make squash-commits`, `git rebase -i` squash/fixup, `git reset --soft` collapse (B25). Adds commit/merge latitude on feature branches; does NOT lift no‑push/no‑squash/no‑force. (B21–B25 are documented in `AGENTS.md`.) |
 
 ---
 
@@ -714,12 +720,19 @@ Follow the §5.2 self‑correct loop:
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>` → `openspec new change`, per B15) + tasks, validate it, and
-  start the loop — according to the **per-channel trigger**:
+  **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree `feat/<name>`,
+  scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives on green,
+  finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing `feat/<name>`
+  as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER touched
+  (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -737,7 +750,7 @@ This file, `AGENTS.md`, and `hermes/skills/openspec-loop-harness.md` are the **s
 truth**. When you change a behaviour, constraint, command, or pitfall in **any one** of them,
 mirror it in the **other two** before considering the change done:
 
-- Repo authority: `AGENTS.md` (phase flow + B1–B25 summary).
+- Repo authority: `AGENTS.md` (phase flow + B1–B26 summary).
 - Skill mirror: `hermes/skills/openspec-loop-harness.md` (operator‑level detail + pitfalls).
 - This guide: `docs/openspec-engineering-loop-harness.md` (human‑readable technical reference).
 

--- a/tests/fixtures/check_docs_sync/in_sync/hermes/skills/openspec-loop-harness.md
+++ b/tests/fixtures/check_docs_sync/in_sync/hermes/skills/openspec-loop-harness.md
@@ -24,7 +24,7 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
   walk), (3) **diagnose & correct by fixing the SOURCE OF TRUTH not the symptom** (edit the spec,
   restore, re-run — never hand-edit generated TS, B11; each pass a *different* tweak), and
   (4) **terminate** (bounded ~5 attempts, then escalate to fixing the Python floor B13). Durable
-  invariants B1–B25 are the loop's "laws of physics" that never regress on any pass.
+  invariants B1–B26 are the loop's "laws of physics" that never regress on any pass.
 - **How they fit:** the harness is the **floor** (nothing worse can be written); the loop is the
   **ratchet** (each pass only moves toward green, invariants never slip). Full write-up:
   `docs/openspec-engineering-loop-harness.md` §0.
@@ -181,12 +181,19 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>` → `openspec new change`, per B15) + tasks, validate it, and
-  start the loop — according to the **per-channel trigger**:
+  **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree `feat/<name>`,
+  scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives on green,
+  finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing `feat/<name>`
+  as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER touched
+  (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -196,7 +203,7 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
   `docs/openspec-engineering-loop-harness.md` (B8). The reusable directive is the Hermes skill
   `request-to-openspec` (loaded at request entry).
 
-## Durable agent behaviours (B1–B25) — MUST always hold, never regress
+## Durable agent behaviours (B1–B26) — MUST always hold, never regress
 
 These are standing rules for the agent (also in `AGENTS.md`). They are enforced by
 `make phase7-archive` and the persistent harness
@@ -269,7 +276,7 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
   different behaviour. The full B8 sync set (enforced by `make check-docs-sync`, the FINAL loop
   stage) also includes `Makefile`, `docs/openspec-engineering-loop-harness.md`, and
   `scripts/run-loop-harness.sh` — all MUST agree on the 8-stage order + final `check-docs-sync`,
-  the `loop-ts-floor` guard, and the B1–B25 range; a drift there fails the loop.
+  the `loop-ts-floor` guard, and the B1–B26 range; a drift there fails the loop.
 - **(B9) Rootless nerdctl bind-mount permissions (READ + WRITE).** Execution is docker compose
   with **rootless nerdctl**, which remaps the container uid (1000) to the host **`other`** class.
   Every file/dir the container must READ (the whole repo, since compose mounts `..:/project`)
@@ -323,15 +330,17 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
   `_expected_contract_for_change`) only reads the spec contract and merges it deterministically —
   it must never author TS bodies. Hand-editing generated TS is forbidden because it bypasses the
   deterministic merge floor and desyncs the spec from the code.
-- **(B12) Delivery gap — verified worktree TS MUST reach the active branch.** The pipeline
+- **(B12) Delivery gap — verified worktree TS MUST reach the target branch as the PR.** The pipeline
   generates + verifies TS **inside a git worktree** (`worktrees/<name>`, branch `feat/<name>`).
   The harness MUST NOT stop there: a feature green only in the worktree that never lands on its
-  target branch is a failed delivery. After `build-app`+`test-app` are green, the agent MUST pull
-  the verified `src/main.ts` + `src/__tests__/main.test.ts` back onto the **current branch's
-  working tree** (e.g. `make deliver-change CHANGE=<name>` — a file copy, NOT a commit; B4 holds).
-  Never declare a change "done" while its generated TS still lives only in the worktree. (AGENTS.md
-  Phase 5's "old TS remains until you deliberately merge the worktree" previously let verified
-  code die in the worktree — B12 overrides that silence.)
+  target branch is a failed delivery. The agent delivers by **pushing the worktree branch as the PR**
+  (`git push origin feat/<name>`, or `make openspec-flow NAME=<name> PUSH=1`) — it MUST NOT copy
+  generated TS back into the parent working tree (that would re-introduce pollution; ALL artifacts
+  stay in the worktree by design — see `openspec-change-worktree-flow`). Corrections redeliver via
+  `make openspec-redeliver NAME=<name>` (`git push --force-with-lease` to the SAME PR branch only;
+  never `main`). Never declare a change "done" while its worktree branch has not been delivered.
+  (Earlier wording told the agent to `make deliver-change` — a file copy onto the current branch —
+  which conflicts with the worktree-confinement invariant; this override supersedes it.)
 - **(B13) Python *floor* defects are fixed directly, not via spec round-trips.** B11's spec-first
   rule applies when the GENERATED TS/test is wrong. If the defect is in the *deterministic floor*
   itself (e.g. the integrator skips injecting the spec contract when the LLM already emitted a same-
@@ -431,7 +440,7 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
  `127.0.0.1:11434` reaches the live Ollama on the docker host), so they must RUN (not skip) — fix
  root resolution, never add an OLLAMA skip guard. (Closed the gap where `test_greetings_contract_unit.py` + `test_slim_refactor_invariants_unit.py` failed post-archive, and where `test_ticket20/ticket22/greetings` e2e errored on `FileNotFoundError: 'openspec'` due to `/app` root resolution.)
     - **(B20) NEVER declare a change "done" without running the loop gate first — hard pre-flight.** Before claiming any OpenSpec change complete (or "harness green/aligned/fixed"), run the gate and report real output:
-      1. **Preferred:** `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`) — all eight stages: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app`. Also `make loop-trigger`.
+      1. **Preferred:** `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`) — all stages: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync`. Also `make loop-trigger`.
       2. **If full `make loop-harness` can't finish** (live Ollama absent for `loop-e2e`/`loop-unit-real`, or npm build times out), STILL run the hermetic gates `make loop-collect` + `make loop-ts-floor` + `make loop-unit` (no external dep) — they MUST be green before any "done".
       3. **Report honestly:** actual per-stage PASS/SKIP/FAIL with the failing stage named. Never say "done/green" if `loop-unit`/`loop-collect` is red; fix the root cause and re-run. Rationale: the agent previously finished work (incl. AGENTS.md/skill edits) WITHOUT running the gate, leaving `make loop-unit` red. B20 makes the gate mandatory so regressions are caught before "done". (B4/B14: no git commit/push from the gate.)
     - **(B21) HITL is OPT-IN and loop-excluded — never a blocking prompt in automation.** `HITLNode`
@@ -498,6 +507,14 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
       graph. The agent MAY commit (B23) and merge/cherry-pick, but must NOT rewrite/squash existing
       history. If history is messy (leaked throwaway commits), FLAG it for the human and ask — do not
       decide unilaterally. `make squash-commits` is human-triggered only. B8: mirror in AGENTS.md.
+    - **(B26) AGENT MAY COMMIT/MERGE ITS OWN CHANGES on a non-main branch when the PRE-COMMIT HOOK
+      PASSES.** Permitted to `git commit` (and `git merge`/`git cherry-pick`) its OWN work-in-progress
+      on a feature branch so it can iterate productively. Bounded by: (1) branch guard — current
+      branch MUST NOT be `main`/`origin/main`/protected; (2) hook guard — `git-hooks/pre-commit`
+      (gitleaks + trailing-whitespace) MUST pass; the agent commits only via the normal `git commit`
+      path, NEVER `--no-verify`. Still forbidden (human-only): `git push` (B14), `make squash-commits`,
+      `git rebase -i` squash/fixup, `git reset --soft` collapse (B25). Adds commit/merge latitude on
+      feature branches; does NOT lift no-push/no-squash/no-force. B8: mirror in AGENTS.md + harness doc.
     ## Plan-B merge refactor (integrator-merge-refactor)
 
 - **Imports:** inject new `import` lines at the top (after the last existing top-level import).

--- a/tests/fixtures/check_docs_sync/in_sync_ascii/AGENTS.md
+++ b/tests/fixtures/check_docs_sync/in_sync_ascii/AGENTS.md
@@ -69,7 +69,7 @@ every spec requirement/scenario); (3) **diagnose & correct by fixing the SOURCE 
 symptom** — edit the OpenSpec spec/contract, restore the generated files to a clean baseline, and
 re-run; NEVER hand-edit generated TS (B11), and each pass must try a *different* correction; and
 (4) **terminate** — a bounded ~5 attempts with a clear escalation (fix the Python floor as a last
-resort, B13). The durable behaviours B1–B25 are the loop's "laws of physics" — invariants that
+resort, B13). The durable behaviours B1–B26 are the loop's "laws of physics" — invariants that
 never regress on any pass (permanent e2e B1–B6, no-commit/no-push gate B4/B14, delivery step B12).
 
 **How they fit:** the harness is the **floor** (nothing worse than the contract can ever be
@@ -398,7 +398,7 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
  coordinate `127.0.0.1:11434` reaches the live Ollama on the docker host), so they must RUN (not
  skip) — root resolution is the actual bug to fix, not a skip guard.
   - **(B20) NEVER declare a change "done" without running the loop gate first — this is a hard pre-flight, not optional.** Before reporting any OpenSpec change as complete (or before claiming "the harness is green / aligned / fixed"), the agent MUST execute the loop gate and report its real output:
-      1. **Preferred:** run `bash scripts/run-loop-harness.sh` (the loop-harness runner — it streams each stage's container/pytest/jest output to the terminal LIVE, prints a start banner + heartbeat on quiet stages, and ends with a per-stage PASS/FAIL/timeout summary; it wraps `make <stage>` in `setsid script … | tee` so nerdctl's forced `--tty` gets a console without deadlocking under an interactive shell). It runs all eight stages in order: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app`. (The standalone `make test-agents-*` / `make run-agentics` commands also self-provide a console via the Makefile `$(call docker_run, …)` helper, which uses `script` only when stdout is not a tty.)
+      1. **Preferred:** run `bash scripts/run-loop-harness.sh` (the loop-harness runner — it streams each stage's container/pytest/jest output to the terminal LIVE, prints a start banner + heartbeat on quiet stages, and ends with a per-stage PASS/FAIL/timeout summary; it wraps `make <stage>` in `setsid script … | tee` so nerdctl's forced `--tty` gets a console without deadlocking under an interactive shell). It runs all stages in order: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync`. (The standalone `make test-agents-*` / `make run-agentics` commands also self-provide a console via the Makefile `$(call docker_run, …)` helper, which uses `script` only when stdout is not a tty.)
          **HOW TO RUN (never make excuses):** long-running `make` targets (`run-agentics`, `build-app`, `test-app`, `loop-harness`, `loop-e2e`, `deliver-change`, `phase7-archive`, `release-flow`) MUST be launched via `terminal(background=true)` — that call executes on the **REAL HOST** (`/home/asimov/repository/git/projects/obsidian-timestamp-utility`), where `make`/`docker`/rootless `nerdctl`/live Ollama all live. The foreground sandbox (`/workspace`) has NO docker/nerdctl and will print `docker: command not found` — that is EXPECTED and is NOT a blocker; the host has it. **Never say "can't run from here" / "environment absent" — the host runs `make` for you.** Drive verification through `make` with REAL output, always.
       2. **If the full `make loop-harness` cannot complete in the session** (e.g. an explicit
          timeout, or a stage is deliberately disabled via env), the agent MUST STILL run the
@@ -437,8 +437,11 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
          sections AND the bump PART.
        - **`make lint-commits`** — run `commitlint` over the squashed range / HEAD; the changelog lint
          gate (fail-closed on any invalid message).
-       - **`make install-git-hooks`** — wire `git-hooks/commit-msg` into `.git/hooks` so every
-         manual `git commit` is linted by commitlint (per-commit Conventional-Commit gate).
+       - **`make install-git-hooks`** — wire `git-hooks/commit-msg` (per-commit Conventional-Commit
+         lint) and `git-hooks/pre-commit` (trailing-whitespace auto-fix) into `.git/hooks` so every
+         manual `git commit` is linted. The pre-commit hook only strips trailing whitespace from
+         staged text files and **never exits non-zero**, so it is inert under the loop (which performs
+         no `git commit`).
        - **`make changelog`** — regenerate sectioned `CHANGELOG.md` (git_chglog; one `## <version>`
          section per git tag, so a local `v<version>` tag after bump yields a viewable new section).
        - **`make release-notes`** — refresh the README release-notes block.
@@ -543,6 +546,26 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
        3. `make squash-commits` is a HUMAN-TRIGGERED command only. The agent may mention it as an
           option, but must not execute it unless the human approved it for the current branch.
      B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md`.
+  - **(B26) AGENT MAY COMMIT/MERGE ITS OWN CHANGES on a non-main branch when the PRE-COMMIT HOOK
+     PASSES.** The agent is permitted to `git commit` (and `git merge`/`git cherry-pick`) its OWN
+     work-in-progress — e.g. landing this feature branch's OpenSpec change, scripts, Makefile, and
+     doc-sync edits — so it can iterate productively without waiting for a human to commit each
+     step. The permission is bounded by two hard conditions:
+       1. **Branch guard:** the current branch MUST NOT be `main` or `origin/main` (nor any other
+          protected branch). On `main`, B4/B14/B25 still forbid the agent from committing/pushing on
+          its own — a human triggers that.
+       2. **Hook guard:** the `git-hooks/pre-commit` (gitleaks secret scan + trailing-whitespace) MUST
+          pass. The agent commits ONLY through the normal `git commit` path so the hook runs; it
+          NEVER uses `--no-verify`. If the hook fails, the commit is blocked and the agent fixes the
+          underlying issue (or stops) rather than bypassing the guard.
+       3. **Still forbidden (human-only):** `git push` (B14), `make squash-commits`, `git rebase -i`
+          with squash/fixup, and `git reset --soft` + collapse (B25). This behaviour ADDS commit/merge
+          latitude on feature branches; it does NOT lift the no-push / no-squash / no-force gates.
+       4. Commits should be atomic and conventionally-scoped (the `git-hooks/commit-msg` lint applies).
+          The agent keeps `tasks.md` ticked as work is verified (B16) and re-runs `make check-docs-sync`
+          when it edits a sync doc.
+     B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md` and
+     `docs/openspec-engineering-loop-harness.md`.
   - **(B7.1) The deterministic floor runs in EVERY mode (incl. fast).** `route_hitl` in
     `composable_workflows.py` previously returned `output_result` when `TEST_FAST_MODE=1` (set by
     `tests/integration/conftest.py` to skip the npm-test phase), which bypassed `integration_testing`
@@ -600,17 +623,18 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
          code lingers and the next run starts clean).
       3. **Re-run** `make run-agentics` to regenerate from the corrected spec, then
          `make build-app` + `make test-app` until green.
-  - **(B12) Delivery gap — the verified worktree TS MUST reach the active branch.** The
-    agentic pipeline generates + verifies TS **inside a git worktree** (`worktrees/<name>`,
-    branch `feat/<name>`). The harness MUST NOT stop there: a feature that is green only in the
-    worktree and never lands on the branch it targets is a failed delivery. After `make
-    build-app` + `make test-app` are green in/for the worktree, the agent MUST pull the verified
-    `src/main.ts` + `src/__tests__/main.test.ts` back onto the **current branch's working tree**
-    (e.g. `make deliver-change CHANGE=<name>`, which copies the worktree files into the repo tree).
-    This is a file copy only — it does NOT commit/push (B4); committing remains a deliberate human
-    step. The agent must NEVER declare a change "done" while its generated TS still lives only in
-    the worktree. (Pitfall: AGENTS.md Phase 5's "the old TS remains until you deliberately merge
-    the worktree" previously let verified code die in the worktree — B12 overrides that silence.)
+  - **(B12) Delivery gap — verified worktree TS MUST reach the target branch as the PR.** The
+    pipeline generates + verifies TS **inside a git worktree** (`worktrees/<name>`, branch
+    `feat/<name>`). The harness MUST NOT stop there: a feature green only in the worktree that never
+    lands on its target branch is a failed delivery. The agent delivers by **pushing the worktree
+    branch as the PR** (`git push origin feat/<name>`, or `make openspec-flow NAME=<name> PUSH=1`) —
+    it MUST NOT copy generated TS back into the parent working tree (that would re-introduce
+    pollution; ALL artifacts stay in the worktree by design — see `openspec-change-worktree-flow`).
+    Corrections redeliver via `make openspec-redeliver NAME=<name>` (`git push --force-with-lease`
+    to the SAME PR branch only; never `main`). Never declare a change "done" while its worktree
+    branch (`feat/<name>`) has not been delivered. (Earlier wording told the agent to
+    `make deliver-change` — a file copy onto the current branch — which conflicts with the
+    worktree-confinement invariant; this override supersedes it.)
     **Bounded self-correct loop (≈5 e2e attempts):** repeat the fix-spec → restore → re-run
     sequence for up to ~5 full e2e runs (`make run-agentics` with that spec file). Each failed
     attempt MUST first try a **different adjustment to the spec/contract file** (tasks.md
@@ -635,8 +659,8 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
   stage order, the `loop-ts-floor` guard, or the B-behaviour range:
   1. **`Makefile`** — the executable gates + canonical stage-order comment; `make loop-harness`
      runs `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e`
-     → `loop-integration` → `loop-build-app` → `loop-test-app` → `check-docs-sync` (final).
-  2. **`AGENTS.md`** — this file: the authoritative narrative + the B1–B25 durable behaviours.
+           → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync` (final).
+  2. **`AGENTS.md`** — this file: the authoritative narrative + the B1–B26 durable behaviours.
   3. **`hermes/skills/openspec-loop-harness.md`** — the loadable skill mirror of AGENTS.md.
   4. **`docs/openspec-engineering-loop-harness.md`** — the human-readable technical reference
      (named by B8 itself as authoritative; MUST be kept in the sync set, not treated as a 4th
@@ -648,7 +672,7 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
      marked `@pytest.mark.e2e`) — the runtime proof the loop works.
   Before claiming "the loop is green / aligned", run `make check-docs-sync` (the final loop stage)
   and confirm it PASSES: all sync docs agree on the 8-stage order + final `check-docs-sync`, the
-  `loop-ts-floor` guard, the B1–B25 behaviours, and the live-test skip rule (`OLLAMA_HOST` only,
+  `loop-ts-floor` guard, the B1–B26 behaviours, and the live-test skip rule (`OLLAMA_HOST` only,
   not `GITHUB_TOKEN`). A change is NOT done while any of the sync docs disagree.
 - The harness is the OpenSpec change: `proposal.md` defines *why*, `specs/**` defines *what must
   hold*, `tasks.md` defines *the steps to run*. The agentic pipeline turns tasks into code+tests.
@@ -678,12 +702,19 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>`, which shells out to `openspec new change` per B15) +
-  tasks, validate it, and start the loop — according to the **per-channel trigger**:
+  tasks, validate it, and **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree
+  `feat/<name>`, scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives
+  on green, finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing
+  `feat/<name>` as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER
+  touched (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -692,3 +723,43 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
   `make openspec-new` / `openspec new change`; do NOT limit itself to kanban tooling.  The reusable directive lives in the Hermes skill
   `request-to-openspec` (loaded at request entry). Mirrored in `openspec-loop-harness.md` and
   `docs/openspec-engineering-loop-harness.md` (B8).
+
+---
+
+## Secret scanning (gitleaks)
+
+The broken TruffleHog GitHub Action was replaced by **gitleaks** (the de-facto open-source scanner).
+The actual secret **scan** lives in the pre-commit hook + CI (NOT a loop-harness stage); the
+secret-scanner's own **pytest suite** runs as a loop-harness stage (`loop-secret-scan-tests`).
+
+- **Engine:** `scripts/secret_scanner.py` delegates 100% of detection to gitleaks — no homemade
+  regex/entropy detector. It is the LOCAL fail-closed **hook** guard (dev-side), not a loop command.
+- **Config:** `.gitleaks.toml` uses `[extend] useDefault = true` plus repo-local `allowlist` entries
+  for test fixtures, docs, dependency/build caches (`.venv`, `node_modules`, `__pycache__`, and so on),
+  and `.env`/`.git`. **Do NOT replace `useDefault = true` with an empty `path`** — that silently
+  disables the entire default ruleset.
+- **Scan lives in the hook + CI (NOT the loop):** the gitleaks repo scan runs in `git-hooks/pre-commit`
+  (`python3 scripts/secret_scanner.py --staged`) and `git-hooks/commit-msg` (`--message-file`), and in
+  CI (`.github/workflows/trufflehog.yml`, `gitleaks/gitleaks-action@v2`). A detected secret blocks the
+  commit / fails CI. A standalone `make loop-secret-scan` target exists for on-demand scans but is NOT
+  a loop stage (the loop must not re-scan the tree — the hook already guards every commit).
+- **Loop stage = the scanner's own tests (containerized, B9):** `make loop-secret-scan-tests` builds
+  `secret-scan-tests-image` (real gitleaks + pytest) and runs `tests/test_secret_scanner*.py` **inside
+  the `gitleaks-tests` compose container** (`docker-compose-files/gitleaks-tests.yaml`), exercising the
+  REAL gitleaks binary (no mocks on detection). It sits between `loop-test-app` and `check-docs-sync`
+  in the canonical stage order. This verifies the scanner's detection logic itself every loop run.
+- **No duplicate scan commands:** the Makefile has exactly ONE on-demand scan target (`loop-secret-scan`,
+  alias `check-secrets`); it does NOT shell out to `python3` or a bare host `gitleaks` binary — docker
+  compose only, like every other harness gate. `make secret-scan-image` / `make secret-scan-tests-image`
+  build images; `make test-secret-scanner` runs the pytest suites on the host. `loop-secret-scan-tests`
+  is the canonical loop entry that runs the suite containerized.
+- **Hooks (fail-closed, local dev guard):** `git-hooks/pre-commit` runs `python3 scripts/secret_scanner.py --staged`;
+  `git-hooks/commit-msg` runs `python3 scripts/secret_scanner.py --message-file`. A detected secret
+  rejects the commit. Installed via `make install-git-hooks`.
+- **CI:** `.github/workflows/trufflehog.yml` is a gitleaks workflow (`gitleaks/gitleaks-action@v2`,
+  `fetch-depth: 0`, `GITLEAKS_CONFIG=.gitleaks.toml`).
+- **Tests:** `tests/test_secret_scanner.py` (hermetic unit) + `tests/test_secret_scanner_integration.py`
+  (real gitleaks binary, no mocks on detection). Run with `make test-secret-scanner` (host) or via the
+  loop stage `loop-secret-scan-tests` (containerized).
+- **Credential hygiene:** never put real API keys/tokens in source or tests. Use documented example
+  shapes (e.g. `AKIA…EXAMPLE`, `xoxb-…`) or `[REDACTED]`.

--- a/tests/fixtures/check_docs_sync/in_sync_ascii/docs/openspec-engineering-loop-harness.md
+++ b/tests/fixtures/check_docs_sync/in_sync_ascii/docs/openspec-engineering-loop-harness.md
@@ -8,7 +8,7 @@
 > 2. **Harness engineering** — the Python "agentics" pipeline (`agents/agentics/`) and
 >    the deterministic merge floor that writes your `src/main.ts` / `src/__tests__/main.test.ts`.
 > 3. **Loop engineering** — the bounded self‑correcting build→test→fix loop and the
->    durable behaviours **B1–B25** that the loop must always honour.
+>    durable behaviours **B1–B26** that the loop must always honour.
 >
 > It also documents the **file structure**, every file that creates the harness's
 > behaviour, and a **how‑to‑use** walkthrough for authoring a new feature.
@@ -21,7 +21,7 @@ at repo root, the previous `docs/openspec-loop-harness-guide.md`) are historical
 ## 0. Fundamentals — what "harness" and "loop" engineering mean
 
 Before the technical detail, understand the two disciplines this whole system is built on.
-Everything below (OpenSpec, the Python pipeline, the Makefile, B1–B25) is just a concrete
+Everything below (OpenSpec, the Python pipeline, the Makefile, B1–B26) is just a concrete
 implementation of these two ideas. If you internalise this section, the rest of the document
 reads as "here is *how* we do harness + loop engineering in this repo."
 
@@ -91,7 +91,7 @@ A well‑engineered loop has four parts:
    a loop with no escalation hides real defects.
 
 The loop is also where **durability** lives: the invariants that must hold on *every* pass
-(B1–B25) — a permanent regression e2e that outlives every feature (B1–B6), the no‑commit/no‑push
+(B1–B26) — a permanent regression e2e that outlives every feature (B1–B6), the no‑commit/no‑push
 gate (B4/B14), the delivery step that moves verified code out of the worktree onto the branch
 (B12). These are the loop's "laws of physics": conditions that never regress no matter how many
 times you go round.
@@ -105,7 +105,7 @@ gate is green, then stop."
 | Discipline | Job | Answers the question | In this repo |
 |-----------|-----|----------------------|--------------|
 | **Harness engineering** | *Constrain* the generator into a verifiable shape | "How do I make one generation trustworthy?" | OpenSpec contract as source of truth + `CodeIntegratorAgent` deterministic merge floor + omission guard + B9 perms + git‑HEAD restore |
-| **Loop engineering** | *Correct* the generator across attempts until an objective gate passes | "How do I make the system converge on correct, and know when to stop?" | `make build-app`/`make test-app` gate + spec‑first self‑correct loop (bounded ~5) + durable behaviours B1–B25 + delivery step B12 |
+| **Loop engineering** | *Correct* the generator across attempts until an objective gate passes | "How do I make the system converge on correct, and know when to stop?" | `make build-app`/`make test-app` gate + spec‑first self‑correct loop (bounded ~5) + durable behaviours B1–B26 + delivery step B12 |
 
 The harness is the **floor** (nothing worse than this can be written); the loop is the **ratchet**
 (each pass can only move toward green, and the invariants never slip back). The rest of this
@@ -148,7 +148,7 @@ Three non‑negotiable principles:
 
 ```
 obsidian-timestamp-utility/
-├── AGENTS.md                         # Repo‑level authority: phase flow + B1–B25 summary
+├── AGENTS.md                         # Repo‑level authority: phase flow + B1–B26 summary
 ├── Makefile                          # ALL execution entry points (docker compose only, no Dagger)
 ├── docker-compose-files/
 │   ├── agents.yaml                   # agentics / unit‑test‑agents / integration‑test‑agents services
@@ -547,18 +547,23 @@ if invoking docker compose outside the Makefile. World‑readable on a private r
 
 `make run-agentics` generates + verifies TS **inside a worktree**. The harness must NOT stop
 there: a feature green only in the worktree that never lands on its target branch is a failed
-delivery. After `build-app`+`test-app` are green, pull the verified files back onto the current
-branch's working tree:
+delivery. Deliver it by **pushing the worktree branch as the PR** — NOT by copying files back into
+the parent working tree (that would re-introduce pollution; ALL artifacts stay in the worktree by
+design — see `openspec-change-worktree-flow`):
 
 ```bash
-make deliver-change CHANGE=<name>     # copies worktree src/main.ts + main.test.ts → repo (file copy, NO commit)
+make openspec-flow NAME=<name> PUSH=1     # creates worktree, archives on green, finalizes, pushes feat/<name> as PR
+# corrections after a pass:
+make openspec-redeliver NAME=<name>        # re-enters worktree, re-squashes, force-pushes to the SAME PR branch (--force-with-lease, never main)
 ```
 
-Never declare a change "done" while its generated TS still lives only in the worktree.
+Never declare a change "done" while its worktree branch (`feat/<name>`) has not been delivered.
+(The earlier `make deliver-change` file-copy directive conflicts with the worktree-confinement
+invariant and is superseded by this PR-push model.)
 
 ---
 
-## 6. Durable behaviours B1–B25 (must always hold, never regress)
+## 6. Durable behaviours B1–B26 (must always hold, never regress)
 
 | ID | Behaviour |
 |----|-----------|
@@ -573,14 +578,15 @@ Never declare a change "done" while its generated TS still lives only in the wor
 | **B9** | Rootless nerdctl bind‑mount permissions (READ+WRITE). Whole repo world‑readable; container write targets world‑writable. Enforced by the `b9-perms` Makefile prerequisite. |
 | **B10** | **NO hard‑coded generated TS/test code in Python** — only contract‑steered. Generated TS bodies live *only* in the change's `tasks.md`/`spec.md` markers; Python only parses + merges + injects verbatim. |
 | **B11** | On generated‑TS failure: **fix the SPEC, then restore, then re‑run** — never edit TS by hand. Bounded ~5‑attempt self‑correct loop; only then may Python floor code be touched as last resort. |
-| **B12** | Delivery gap — verified worktree TS MUST reach the active branch (`make deliver-change`). Never declare done while TS lives only in the worktree. |
+| **B12** | Delivery gap — verified worktree TS MUST reach the target branch as the PR (`make openspec-flow NAME=<name> PUSH=1` → `git push feat/<name>`; corrections via `make openspec-redeliver` force-push to the SAME PR branch). NEVER a file copy into the parent working tree (worktree-confinement invariant). Never declare done while the worktree branch is undelivered. |
 | **B13** | Python *floor* defects are fixed directly, not via spec round‑trips. If the defect is in the deterministic floor itself, fix `CodeIntegratorAgent` — that is the correct spec‑steered fix; only the *merge logic* is corrected, the contract TS body still comes from the spec. |
 | **B14** | Commit/push gating for *new* code (human‑only, behaviour‑scoped). Code is committed ONLY if NEW; pushed ONLY if that new code is part of a behaviour. Floor/integrator Python fixes MAY be committed (and pushed only when part of a committed behaviour) **once**: `build-app`=0, `test-app`=0, passing‑test count **>** previous run, and all OpenSpec checks clean. Rule of thumb: commit only if new AND build works AND tests pass > last run AND OpenSpec clean; push only if that commit is the behaviour landing. **Never squash/rebase/force‑push.** |
 | **B15** | **GitHub issue → local OpenSpec change via the OpenSpec CLI (seed‑then‑generate).** When a change is sourced from a GitHub issue, the agentic code MUST turn it into a local OpenSpec change by **shelling out to `openspec new change ticket<N>`** (the same CLI step a human runs) — never hand‑writing the directory, never a raw `Path.write_text` for the directory shape. `fetch_issue_agent.py` calls `openspec_loader.create_change_from_issue(url, title, body)` after the fetch; that scaffolds via the CLI, fills `proposal.md`/`specs/<cap>/spec.md`/`tasks.md` from the issue, and re‑points generation to `openspec:ticket<N>` so the rest of the loop runs offline. The change name is derived deterministically from the issue URL (`.../issues/20` → `ticket20`), so re‑runs are idempotent. The seeded `openspec/changes/ticket<N>/` is a RUNTIME artifact and MUST NOT be committed (extends B4); `ticket20`/`ticket22` e2e tests generate + clean it up in `finally`. Keeps B10 honest: the exact `openspec new change` a human runs is the one the pipeline runs. |
 | **B16** | **Task‑completion discipline — tick as you verify, never leave open tasks, archive gate fails closed.** `make phase7-archive` runs `openspec_loader.assert_no_open_tasks` BEFORE `openspec archive` and refuses (non‑zero exit, no spec merge) if any `- [ ]` task remains. A change is "done" only when all tasks are ticked AND verified AND archived. `make loop-tasks` lists open/done per change so the backlog is never invisible. |
-| **B17** | **Integration suite is a mandatory loop phase; no dead tests; live tests skip cleanly.** `make loop-harness` runs EIGHT loop stages plus a FINAL B8 doc-sync gate: a collection guard (gate 0), a strict TS test/command floor (gate 0.5), followed by six gates (1–6): `loop-collect` (hermetic collection guard) → `loop-ts-floor` (STRICT TS test/command floor — FAIL if the current branch's `describe`/leaf `it`/`test`/jest-collected/`addCommand` counts drop below `origin/main`) → `loop-unit` (mocked, hermetic) → `loop-unit-real` (REAL agent unit tests on live Ollama, no mocks) → `loop-e2e` (B1/B3 e2e) → `loop-integration` (broad suite) → `loop-build-app` → `loop-test-app`, then `check-docs-sync` (FINAL B8 gate — FAIL if any sync doc drifts on stage order / `loop-ts-floor` / B-range). No dead duplicates; live tests `skipif` cleanly on `OLLAMA_HOST`. |
+| **B17** | **Integration suite is a mandatory loop phase; no dead tests; live tests skip cleanly.** `make loop-harness` runs EIGHT loop stages plus a FINAL B8 doc-sync gate: a collection guard (gate 0), a strict TS test/command floor (gate 0.5), followed by six gates (1–6): `loop-collect` (hermetic collection guard) → `loop-ts-floor` (STRICT TS test/command floor — FAIL if the current branch's `describe`/leaf `it`/`test`/jest-collected/`addCommand` counts drop below `origin/main`) → `loop-unit` (mocked, hermetic) → `loop-unit-real` (REAL agent unit tests on live Ollama, no mocks) → `loop-e2e` (B1/B3 e2e) → `loop-integration` (broad suite) → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` (secret-scanner pytest suite, containerized, real gitleaks, fail-closed; the actual gitleaks tree-scan lives in the pre-commit hook + CI, not the loop), then `check-docs-sync` (FINAL B8 gate — FAIL if any sync doc drifts on stage order / `loop-ts-floor` / B-range). No dead duplicates; live tests `skipif` cleanly on `OLLAMA_HOST`. |
 | **B18** | **Run the agents' REAL unit tests, not only the mocked ones.** The loop MUST execute BOTH the hermetic mocked unit run (`loop-unit` → `test-agents-unit-mock`) AND the real, non‑mocked agent unit run (`loop-unit-real` → `test-agents-unit`, live Ollama) as gates 1 and 2. Reporting "agent tests green" after ONLY the mocked run is INCOMPLETE. `test-agents-unit` MUST be run when Ollama is reachable and its result reported alongside — not instead of — the mocked run. If Ollama is unreachable, `loop-unit-real` SKIPS (must not error) but the agent MUST state the real unit gate did not run. |
 | **B20** | **NEVER declare a change "done" without running the loop gate first — hard pre-flight.** Before claiming any OpenSpec change complete (or "harness green/aligned/fixed"), run the gate and report real output. Preferred: `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`, also `make loop-trigger`) — all eight stages. **HOW TO RUN: long-running `make` targets (`run-agentics`, `build-app`, `test-app`, `loop-harness`, `loop-e2e`, `deliver-change`, `phase7-archive`, `release-flow`) MUST be launched via `terminal(background=true)` — that call executes on the REAL HOST (`/home/asimov/repository/git/projects/obsidian-timestamp-utility`), where `make`/`docker`/rootless `nerdctl`/live Ollama all live. The foreground sandbox (`/workspace`) has NO docker/nerdctl and will say `docker: command not found` — that is EXPECTED and is NOT a blocker; the host has it.** The host provides rootless `nerdctl` AND a live Ollama (host-networked, so `127.0.0.1:11434` reaches it — B19), so `loop-unit-real` and `loop-e2e` are EXPECTED to RUN, not skip. Only STILL run the hermetic gates `make loop-collect` + `make loop-ts-floor` + `make loop-unit` (no external dep) when a stage truly cannot finish in the session; they MUST be green before any "done". Report honestly (PASS/SKIP/FAIL, failing stage named); never claim green if `loop-unit`/`loop-collect` is red; **never claim "can't run from here" — the host runs `make` for you.** Fix root cause and re-run. (B4/B14: no git commit/push from the gate.) |
+| **B26** | **AGENT MAY COMMIT/MERGE ITS OWN CHANGES on a non‑main branch when the PRE‑COMMIT HOOK PASSES.** Permitted to `git commit` (and `git merge`/`git cherry‑pick`) its OWN work‑in‑progress on a feature branch so it can iterate productively. Bounded by: (1) branch guard — current branch MUST NOT be `main`/`origin/main`/protected; (2) hook guard — `git-hooks/pre-commit` (gitleaks + trailing‑whitespace) MUST pass; the agent commits only via the normal `git commit` path, NEVER `--no-verify`. Still forbidden (human‑only): `git push` (B14), `make squash-commits`, `git rebase -i` squash/fixup, `git reset --soft` collapse (B25). Adds commit/merge latitude on feature branches; does NOT lift no‑push/no‑squash/no‑force. (B21–B25 are documented in `AGENTS.md`.) |
 
 ---
 
@@ -714,12 +720,19 @@ Follow the §5.2 self‑correct loop:
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>` → `openspec new change`, per B15) + tasks, validate it, and
-  start the loop — according to the **per-channel trigger**:
+  **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree `feat/<name>`,
+  scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives on green,
+  finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing `feat/<name>`
+  as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER touched
+  (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -737,7 +750,7 @@ This file, `AGENTS.md`, and `hermes/skills/openspec-loop-harness.md` are the **s
 truth**. When you change a behaviour, constraint, command, or pitfall in **any one** of them,
 mirror it in the **other two** before considering the change done:
 
-- Repo authority: `AGENTS.md` (phase flow + B1–B25 summary).
+- Repo authority: `AGENTS.md` (phase flow + B1–B26 summary).
 - Skill mirror: `hermes/skills/openspec-loop-harness.md` (operator‑level detail + pitfalls).
 - This guide: `docs/openspec-engineering-loop-harness.md` (human‑readable technical reference).
 

--- a/tests/fixtures/check_docs_sync/in_sync_ascii/hermes/skills/openspec-loop-harness.md
+++ b/tests/fixtures/check_docs_sync/in_sync_ascii/hermes/skills/openspec-loop-harness.md
@@ -24,7 +24,7 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
   walk), (3) **diagnose & correct by fixing the SOURCE OF TRUTH not the symptom** (edit the spec,
   restore, re-run — never hand-edit generated TS, B11; each pass a *different* tweak), and
   (4) **terminate** (bounded ~5 attempts, then escalate to fixing the Python floor B13). Durable
-  invariants B1–B25 are the loop's "laws of physics" that never regress on any pass.
+  invariants B1–B26 are the loop's "laws of physics" that never regress on any pass.
 - **How they fit:** the harness is the **floor** (nothing worse can be written); the loop is the
   **ratchet** (each pass only moves toward green, invariants never slip). Full write-up:
   `docs/openspec-engineering-loop-harness.md` §0.
@@ -181,12 +181,19 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>` → `openspec new change`, per B15) + tasks, validate it, and
-  start the loop — according to the **per-channel trigger**:
+  **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree `feat/<name>`,
+  scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives on green,
+  finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing `feat/<name>`
+  as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER touched
+  (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -196,7 +203,7 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
   `docs/openspec-engineering-loop-harness.md` (B8). The reusable directive is the Hermes skill
   `request-to-openspec` (loaded at request entry).
 
-## Durable agent behaviours (B1–B25) — MUST always hold, never regress
+## Durable agent behaviours (B1–B26) — MUST always hold, never regress
 
 These are standing rules for the agent (also in `AGENTS.md`). They are enforced by
 `make phase7-archive` and the persistent harness
@@ -269,7 +276,7 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
   different behaviour. The full B8 sync set (enforced by `make check-docs-sync`, the FINAL loop
   stage) also includes `Makefile`, `docs/openspec-engineering-loop-harness.md`, and
   `scripts/run-loop-harness.sh` — all MUST agree on the 8-stage order + final `check-docs-sync`,
-  the `loop-ts-floor` guard, and the B1–B25 range; a drift there fails the loop.
+  the `loop-ts-floor` guard, and the B1–B26 range; a drift there fails the loop.
 - **(B9) Rootless nerdctl bind-mount permissions (READ + WRITE).** Execution is docker compose
   with **rootless nerdctl**, which remaps the container uid (1000) to the host **`other`** class.
   Every file/dir the container must READ (the whole repo, since compose mounts `..:/project`)
@@ -323,15 +330,17 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
   `_expected_contract_for_change`) only reads the spec contract and merges it deterministically —
   it must never author TS bodies. Hand-editing generated TS is forbidden because it bypasses the
   deterministic merge floor and desyncs the spec from the code.
-- **(B12) Delivery gap — verified worktree TS MUST reach the active branch.** The pipeline
+- **(B12) Delivery gap — verified worktree TS MUST reach the target branch as the PR.** The pipeline
   generates + verifies TS **inside a git worktree** (`worktrees/<name>`, branch `feat/<name>`).
   The harness MUST NOT stop there: a feature green only in the worktree that never lands on its
-  target branch is a failed delivery. After `build-app`+`test-app` are green, the agent MUST pull
-  the verified `src/main.ts` + `src/__tests__/main.test.ts` back onto the **current branch's
-  working tree** (e.g. `make deliver-change CHANGE=<name>` — a file copy, NOT a commit; B4 holds).
-  Never declare a change "done" while its generated TS still lives only in the worktree. (AGENTS.md
-  Phase 5's "old TS remains until you deliberately merge the worktree" previously let verified
-  code die in the worktree — B12 overrides that silence.)
+  target branch is a failed delivery. The agent delivers by **pushing the worktree branch as the PR**
+  (`git push origin feat/<name>`, or `make openspec-flow NAME=<name> PUSH=1`) — it MUST NOT copy
+  generated TS back into the parent working tree (that would re-introduce pollution; ALL artifacts
+  stay in the worktree by design — see `openspec-change-worktree-flow`). Corrections redeliver via
+  `make openspec-redeliver NAME=<name>` (`git push --force-with-lease` to the SAME PR branch only;
+  never `main`). Never declare a change "done" while its worktree branch has not been delivered.
+  (Earlier wording told the agent to `make deliver-change` — a file copy onto the current branch —
+  which conflicts with the worktree-confinement invariant; this override supersedes it.)
 - **(B13) Python *floor* defects are fixed directly, not via spec round-trips.** B11's spec-first
   rule applies when the GENERATED TS/test is wrong. If the defect is in the *deterministic floor*
   itself (e.g. the integrator skips injecting the spec contract when the LLM already emitted a same-
@@ -431,7 +440,7 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
  `127.0.0.1:11434` reaches the live Ollama on the docker host), so they must RUN (not skip) — fix
  root resolution, never add an OLLAMA skip guard. (Closed the gap where `test_greetings_contract_unit.py` + `test_slim_refactor_invariants_unit.py` failed post-archive, and where `test_ticket20/ticket22/greetings` e2e errored on `FileNotFoundError: 'openspec'` due to `/app` root resolution.)
     - **(B20) NEVER declare a change "done" without running the loop gate first — hard pre-flight.** Before claiming any OpenSpec change complete (or "harness green/aligned/fixed"), run the gate and report real output:
-      1. **Preferred:** `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`) — all eight stages: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app`. Also `make loop-trigger`.
+      1. **Preferred:** `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`) — all stages: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync`. Also `make loop-trigger`.
       2. **If full `make loop-harness` can't finish** (live Ollama absent for `loop-e2e`/`loop-unit-real`, or npm build times out), STILL run the hermetic gates `make loop-collect` + `make loop-ts-floor` + `make loop-unit` (no external dep) — they MUST be green before any "done".
       3. **Report honestly:** actual per-stage PASS/SKIP/FAIL with the failing stage named. Never say "done/green" if `loop-unit`/`loop-collect` is red; fix the root cause and re-run. Rationale: the agent previously finished work (incl. AGENTS.md/skill edits) WITHOUT running the gate, leaving `make loop-unit` red. B20 makes the gate mandatory so regressions are caught before "done". (B4/B14: no git commit/push from the gate.)
     - **(B21) HITL is OPT-IN and loop-excluded — never a blocking prompt in automation.** `HITLNode`
@@ -498,6 +507,14 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
       graph. The agent MAY commit (B23) and merge/cherry-pick, but must NOT rewrite/squash existing
       history. If history is messy (leaked throwaway commits), FLAG it for the human and ask — do not
       decide unilaterally. `make squash-commits` is human-triggered only. B8: mirror in AGENTS.md.
+    - **(B26) AGENT MAY COMMIT/MERGE ITS OWN CHANGES on a non-main branch when the PRE-COMMIT HOOK
+      PASSES.** Permitted to `git commit` (and `git merge`/`git cherry-pick`) its OWN work-in-progress
+      on a feature branch so it can iterate productively. Bounded by: (1) branch guard — current
+      branch MUST NOT be `main`/`origin/main`/protected; (2) hook guard — `git-hooks/pre-commit`
+      (gitleaks + trailing-whitespace) MUST pass; the agent commits only via the normal `git commit`
+      path, NEVER `--no-verify`. Still forbidden (human-only): `git push` (B14), `make squash-commits`,
+      `git rebase -i` squash/fixup, `git reset --soft` collapse (B25). Adds commit/merge latitude on
+      feature branches; does NOT lift no-push/no-squash/no-force. B8: mirror in AGENTS.md + harness doc.
     ## Plan-B merge refactor (integrator-merge-refactor)
 
 - **Imports:** inject new `import` lines at the top (after the last existing top-level import).

--- a/tests/fixtures/check_docs_sync/in_sync_en_dash/AGENTS.md
+++ b/tests/fixtures/check_docs_sync/in_sync_en_dash/AGENTS.md
@@ -69,7 +69,7 @@ every spec requirement/scenario); (3) **diagnose & correct by fixing the SOURCE 
 symptom** — edit the OpenSpec spec/contract, restore the generated files to a clean baseline, and
 re-run; NEVER hand-edit generated TS (B11), and each pass must try a *different* correction; and
 (4) **terminate** — a bounded ~5 attempts with a clear escalation (fix the Python floor as a last
-resort, B13). The durable behaviours B1–B25 are the loop's "laws of physics" — invariants that
+resort, B13). The durable behaviours B1–B26 are the loop's "laws of physics" — invariants that
 never regress on any pass (permanent e2e B1–B6, no-commit/no-push gate B4/B14, delivery step B12).
 
 **How they fit:** the harness is the **floor** (nothing worse than the contract can ever be
@@ -398,7 +398,7 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
  coordinate `127.0.0.1:11434` reaches the live Ollama on the docker host), so they must RUN (not
  skip) — root resolution is the actual bug to fix, not a skip guard.
   - **(B20) NEVER declare a change "done" without running the loop gate first — this is a hard pre-flight, not optional.** Before reporting any OpenSpec change as complete (or before claiming "the harness is green / aligned / fixed"), the agent MUST execute the loop gate and report its real output:
-      1. **Preferred:** run `bash scripts/run-loop-harness.sh` (the loop-harness runner — it streams each stage's container/pytest/jest output to the terminal LIVE, prints a start banner + heartbeat on quiet stages, and ends with a per-stage PASS/FAIL/timeout summary; it wraps `make <stage>` in `setsid script … | tee` so nerdctl's forced `--tty` gets a console without deadlocking under an interactive shell). It runs all eight stages in order: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app`. (The standalone `make test-agents-*` / `make run-agentics` commands also self-provide a console via the Makefile `$(call docker_run, …)` helper, which uses `script` only when stdout is not a tty.)
+      1. **Preferred:** run `bash scripts/run-loop-harness.sh` (the loop-harness runner — it streams each stage's container/pytest/jest output to the terminal LIVE, prints a start banner + heartbeat on quiet stages, and ends with a per-stage PASS/FAIL/timeout summary; it wraps `make <stage>` in `setsid script … | tee` so nerdctl's forced `--tty` gets a console without deadlocking under an interactive shell). It runs all stages in order: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync`. (The standalone `make test-agents-*` / `make run-agentics` commands also self-provide a console via the Makefile `$(call docker_run, …)` helper, which uses `script` only when stdout is not a tty.)
          **HOW TO RUN (never make excuses):** long-running `make` targets (`run-agentics`, `build-app`, `test-app`, `loop-harness`, `loop-e2e`, `deliver-change`, `phase7-archive`, `release-flow`) MUST be launched via `terminal(background=true)` — that call executes on the **REAL HOST** (`/home/asimov/repository/git/projects/obsidian-timestamp-utility`), where `make`/`docker`/rootless `nerdctl`/live Ollama all live. The foreground sandbox (`/workspace`) has NO docker/nerdctl and will print `docker: command not found` — that is EXPECTED and is NOT a blocker; the host has it. **Never say "can't run from here" / "environment absent" — the host runs `make` for you.** Drive verification through `make` with REAL output, always.
       2. **If the full `make loop-harness` cannot complete in the session** (e.g. an explicit
          timeout, or a stage is deliberately disabled via env), the agent MUST STILL run the
@@ -437,8 +437,11 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
          sections AND the bump PART.
        - **`make lint-commits`** — run `commitlint` over the squashed range / HEAD; the changelog lint
          gate (fail-closed on any invalid message).
-       - **`make install-git-hooks`** — wire `git-hooks/commit-msg` into `.git/hooks` so every
-         manual `git commit` is linted by commitlint (per-commit Conventional-Commit gate).
+       - **`make install-git-hooks`** — wire `git-hooks/commit-msg` (per-commit Conventional-Commit
+         lint) and `git-hooks/pre-commit` (trailing-whitespace auto-fix) into `.git/hooks` so every
+         manual `git commit` is linted. The pre-commit hook only strips trailing whitespace from
+         staged text files and **never exits non-zero**, so it is inert under the loop (which performs
+         no `git commit`).
        - **`make changelog`** — regenerate sectioned `CHANGELOG.md` (git_chglog; one `## <version>`
          section per git tag, so a local `v<version>` tag after bump yields a viewable new section).
        - **`make release-notes`** — refresh the README release-notes block.
@@ -543,6 +546,26 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
        3. `make squash-commits` is a HUMAN-TRIGGERED command only. The agent may mention it as an
           option, but must not execute it unless the human approved it for the current branch.
      B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md`.
+  - **(B26) AGENT MAY COMMIT/MERGE ITS OWN CHANGES on a non-main branch when the PRE-COMMIT HOOK
+     PASSES.** The agent is permitted to `git commit` (and `git merge`/`git cherry-pick`) its OWN
+     work-in-progress — e.g. landing this feature branch's OpenSpec change, scripts, Makefile, and
+     doc-sync edits — so it can iterate productively without waiting for a human to commit each
+     step. The permission is bounded by two hard conditions:
+       1. **Branch guard:** the current branch MUST NOT be `main` or `origin/main` (nor any other
+          protected branch). On `main`, B4/B14/B25 still forbid the agent from committing/pushing on
+          its own — a human triggers that.
+       2. **Hook guard:** the `git-hooks/pre-commit` (gitleaks secret scan + trailing-whitespace) MUST
+          pass. The agent commits ONLY through the normal `git commit` path so the hook runs; it
+          NEVER uses `--no-verify`. If the hook fails, the commit is blocked and the agent fixes the
+          underlying issue (or stops) rather than bypassing the guard.
+       3. **Still forbidden (human-only):** `git push` (B14), `make squash-commits`, `git rebase -i`
+          with squash/fixup, and `git reset --soft` + collapse (B25). This behaviour ADDS commit/merge
+          latitude on feature branches; it does NOT lift the no-push / no-squash / no-force gates.
+       4. Commits should be atomic and conventionally-scoped (the `git-hooks/commit-msg` lint applies).
+          The agent keeps `tasks.md` ticked as work is verified (B16) and re-runs `make check-docs-sync`
+          when it edits a sync doc.
+     B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md` and
+     `docs/openspec-engineering-loop-harness.md`.
   - **(B7.1) The deterministic floor runs in EVERY mode (incl. fast).** `route_hitl` in
     `composable_workflows.py` previously returned `output_result` when `TEST_FAST_MODE=1` (set by
     `tests/integration/conftest.py` to skip the npm-test phase), which bypassed `integration_testing`
@@ -600,17 +623,18 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
          code lingers and the next run starts clean).
       3. **Re-run** `make run-agentics` to regenerate from the corrected spec, then
          `make build-app` + `make test-app` until green.
-  - **(B12) Delivery gap — the verified worktree TS MUST reach the active branch.** The
-    agentic pipeline generates + verifies TS **inside a git worktree** (`worktrees/<name>`,
-    branch `feat/<name>`). The harness MUST NOT stop there: a feature that is green only in the
-    worktree and never lands on the branch it targets is a failed delivery. After `make
-    build-app` + `make test-app` are green in/for the worktree, the agent MUST pull the verified
-    `src/main.ts` + `src/__tests__/main.test.ts` back onto the **current branch's working tree**
-    (e.g. `make deliver-change CHANGE=<name>`, which copies the worktree files into the repo tree).
-    This is a file copy only — it does NOT commit/push (B4); committing remains a deliberate human
-    step. The agent must NEVER declare a change "done" while its generated TS still lives only in
-    the worktree. (Pitfall: AGENTS.md Phase 5's "the old TS remains until you deliberately merge
-    the worktree" previously let verified code die in the worktree — B12 overrides that silence.)
+  - **(B12) Delivery gap — verified worktree TS MUST reach the target branch as the PR.** The
+    pipeline generates + verifies TS **inside a git worktree** (`worktrees/<name>`, branch
+    `feat/<name>`). The harness MUST NOT stop there: a feature green only in the worktree that never
+    lands on its target branch is a failed delivery. The agent delivers by **pushing the worktree
+    branch as the PR** (`git push origin feat/<name>`, or `make openspec-flow NAME=<name> PUSH=1`) —
+    it MUST NOT copy generated TS back into the parent working tree (that would re-introduce
+    pollution; ALL artifacts stay in the worktree by design — see `openspec-change-worktree-flow`).
+    Corrections redeliver via `make openspec-redeliver NAME=<name>` (`git push --force-with-lease`
+    to the SAME PR branch only; never `main`). Never declare a change "done" while its worktree
+    branch (`feat/<name>`) has not been delivered. (Earlier wording told the agent to
+    `make deliver-change` — a file copy onto the current branch — which conflicts with the
+    worktree-confinement invariant; this override supersedes it.)
     **Bounded self-correct loop (≈5 e2e attempts):** repeat the fix-spec → restore → re-run
     sequence for up to ~5 full e2e runs (`make run-agentics` with that spec file). Each failed
     attempt MUST first try a **different adjustment to the spec/contract file** (tasks.md
@@ -635,8 +659,8 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
   stage order, the `loop-ts-floor` guard, or the B-behaviour range:
   1. **`Makefile`** — the executable gates + canonical stage-order comment; `make loop-harness`
      runs `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e`
-     → `loop-integration` → `loop-build-app` → `loop-test-app` → `check-docs-sync` (final).
-  2. **`AGENTS.md`** — this file: the authoritative narrative + the B1–B25 durable behaviours.
+           → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync` (final).
+  2. **`AGENTS.md`** — this file: the authoritative narrative + the B1–B26 durable behaviours.
   3. **`hermes/skills/openspec-loop-harness.md`** — the loadable skill mirror of AGENTS.md.
   4. **`docs/openspec-engineering-loop-harness.md`** — the human-readable technical reference
      (named by B8 itself as authoritative; MUST be kept in the sync set, not treated as a 4th
@@ -648,7 +672,7 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
      marked `@pytest.mark.e2e`) — the runtime proof the loop works.
   Before claiming "the loop is green / aligned", run `make check-docs-sync` (the final loop stage)
   and confirm it PASSES: all sync docs agree on the 8-stage order + final `check-docs-sync`, the
-  `loop-ts-floor` guard, the B1–B25 behaviours, and the live-test skip rule (`OLLAMA_HOST` only,
+  `loop-ts-floor` guard, the B1–B26 behaviours, and the live-test skip rule (`OLLAMA_HOST` only,
   not `GITHUB_TOKEN`). A change is NOT done while any of the sync docs disagree.
 - The harness is the OpenSpec change: `proposal.md` defines *why*, `specs/**` defines *what must
   hold*, `tasks.md` defines *the steps to run*. The agentic pipeline turns tasks into code+tests.
@@ -678,12 +702,19 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>`, which shells out to `openspec new change` per B15) +
-  tasks, validate it, and start the loop — according to the **per-channel trigger**:
+  tasks, validate it, and **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree
+  `feat/<name>`, scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives
+  on green, finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing
+  `feat/<name>` as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER
+  touched (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -692,3 +723,43 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
   `make openspec-new` / `openspec new change`; do NOT limit itself to kanban tooling.  The reusable directive lives in the Hermes skill
   `request-to-openspec` (loaded at request entry). Mirrored in `openspec-loop-harness.md` and
   `docs/openspec-engineering-loop-harness.md` (B8).
+
+---
+
+## Secret scanning (gitleaks)
+
+The broken TruffleHog GitHub Action was replaced by **gitleaks** (the de-facto open-source scanner).
+The actual secret **scan** lives in the pre-commit hook + CI (NOT a loop-harness stage); the
+secret-scanner's own **pytest suite** runs as a loop-harness stage (`loop-secret-scan-tests`).
+
+- **Engine:** `scripts/secret_scanner.py` delegates 100% of detection to gitleaks — no homemade
+  regex/entropy detector. It is the LOCAL fail-closed **hook** guard (dev-side), not a loop command.
+- **Config:** `.gitleaks.toml` uses `[extend] useDefault = true` plus repo-local `allowlist` entries
+  for test fixtures, docs, dependency/build caches (`.venv`, `node_modules`, `__pycache__`, and so on),
+  and `.env`/`.git`. **Do NOT replace `useDefault = true` with an empty `path`** — that silently
+  disables the entire default ruleset.
+- **Scan lives in the hook + CI (NOT the loop):** the gitleaks repo scan runs in `git-hooks/pre-commit`
+  (`python3 scripts/secret_scanner.py --staged`) and `git-hooks/commit-msg` (`--message-file`), and in
+  CI (`.github/workflows/trufflehog.yml`, `gitleaks/gitleaks-action@v2`). A detected secret blocks the
+  commit / fails CI. A standalone `make loop-secret-scan` target exists for on-demand scans but is NOT
+  a loop stage (the loop must not re-scan the tree — the hook already guards every commit).
+- **Loop stage = the scanner's own tests (containerized, B9):** `make loop-secret-scan-tests` builds
+  `secret-scan-tests-image` (real gitleaks + pytest) and runs `tests/test_secret_scanner*.py` **inside
+  the `gitleaks-tests` compose container** (`docker-compose-files/gitleaks-tests.yaml`), exercising the
+  REAL gitleaks binary (no mocks on detection). It sits between `loop-test-app` and `check-docs-sync`
+  in the canonical stage order. This verifies the scanner's detection logic itself every loop run.
+- **No duplicate scan commands:** the Makefile has exactly ONE on-demand scan target (`loop-secret-scan`,
+  alias `check-secrets`); it does NOT shell out to `python3` or a bare host `gitleaks` binary — docker
+  compose only, like every other harness gate. `make secret-scan-image` / `make secret-scan-tests-image`
+  build images; `make test-secret-scanner` runs the pytest suites on the host. `loop-secret-scan-tests`
+  is the canonical loop entry that runs the suite containerized.
+- **Hooks (fail-closed, local dev guard):** `git-hooks/pre-commit` runs `python3 scripts/secret_scanner.py --staged`;
+  `git-hooks/commit-msg` runs `python3 scripts/secret_scanner.py --message-file`. A detected secret
+  rejects the commit. Installed via `make install-git-hooks`.
+- **CI:** `.github/workflows/trufflehog.yml` is a gitleaks workflow (`gitleaks/gitleaks-action@v2`,
+  `fetch-depth: 0`, `GITLEAKS_CONFIG=.gitleaks.toml`).
+- **Tests:** `tests/test_secret_scanner.py` (hermetic unit) + `tests/test_secret_scanner_integration.py`
+  (real gitleaks binary, no mocks on detection). Run with `make test-secret-scanner` (host) or via the
+  loop stage `loop-secret-scan-tests` (containerized).
+- **Credential hygiene:** never put real API keys/tokens in source or tests. Use documented example
+  shapes (e.g. `AKIA…EXAMPLE`, `xoxb-…`) or `[REDACTED]`.

--- a/tests/fixtures/check_docs_sync/in_sync_en_dash/docs/openspec-engineering-loop-harness.md
+++ b/tests/fixtures/check_docs_sync/in_sync_en_dash/docs/openspec-engineering-loop-harness.md
@@ -8,7 +8,7 @@
 > 2. **Harness engineering** — the Python "agentics" pipeline (`agents/agentics/`) and
 >    the deterministic merge floor that writes your `src/main.ts` / `src/__tests__/main.test.ts`.
 > 3. **Loop engineering** — the bounded self‑correcting build→test→fix loop and the
->    durable behaviours **B1–B25** that the loop must always honour.
+>    durable behaviours **B1–B26** that the loop must always honour.
 >
 > It also documents the **file structure**, every file that creates the harness's
 > behaviour, and a **how‑to‑use** walkthrough for authoring a new feature.
@@ -21,7 +21,7 @@ at repo root, the previous `docs/openspec-loop-harness-guide.md`) are historical
 ## 0. Fundamentals — what "harness" and "loop" engineering mean
 
 Before the technical detail, understand the two disciplines this whole system is built on.
-Everything below (OpenSpec, the Python pipeline, the Makefile, B1–B25) is just a concrete
+Everything below (OpenSpec, the Python pipeline, the Makefile, B1–B26) is just a concrete
 implementation of these two ideas. If you internalise this section, the rest of the document
 reads as "here is *how* we do harness + loop engineering in this repo."
 
@@ -91,7 +91,7 @@ A well‑engineered loop has four parts:
    a loop with no escalation hides real defects.
 
 The loop is also where **durability** lives: the invariants that must hold on *every* pass
-(B1–B25) — a permanent regression e2e that outlives every feature (B1–B6), the no‑commit/no‑push
+(B1–B26) — a permanent regression e2e that outlives every feature (B1–B6), the no‑commit/no‑push
 gate (B4/B14), the delivery step that moves verified code out of the worktree onto the branch
 (B12). These are the loop's "laws of physics": conditions that never regress no matter how many
 times you go round.
@@ -105,7 +105,7 @@ gate is green, then stop."
 | Discipline | Job | Answers the question | In this repo |
 |-----------|-----|----------------------|--------------|
 | **Harness engineering** | *Constrain* the generator into a verifiable shape | "How do I make one generation trustworthy?" | OpenSpec contract as source of truth + `CodeIntegratorAgent` deterministic merge floor + omission guard + B9 perms + git‑HEAD restore |
-| **Loop engineering** | *Correct* the generator across attempts until an objective gate passes | "How do I make the system converge on correct, and know when to stop?" | `make build-app`/`make test-app` gate + spec‑first self‑correct loop (bounded ~5) + durable behaviours B1–B25 + delivery step B12 |
+| **Loop engineering** | *Correct* the generator across attempts until an objective gate passes | "How do I make the system converge on correct, and know when to stop?" | `make build-app`/`make test-app` gate + spec‑first self‑correct loop (bounded ~5) + durable behaviours B1–B26 + delivery step B12 |
 
 The harness is the **floor** (nothing worse than this can be written); the loop is the **ratchet**
 (each pass can only move toward green, and the invariants never slip back). The rest of this
@@ -148,7 +148,7 @@ Three non‑negotiable principles:
 
 ```
 obsidian-timestamp-utility/
-├── AGENTS.md                         # Repo‑level authority: phase flow + B1–B25 summary
+├── AGENTS.md                         # Repo‑level authority: phase flow + B1–B26 summary
 ├── Makefile                          # ALL execution entry points (docker compose only, no Dagger)
 ├── docker-compose-files/
 │   ├── agents.yaml                   # agentics / unit‑test‑agents / integration‑test‑agents services
@@ -547,18 +547,23 @@ if invoking docker compose outside the Makefile. World‑readable on a private r
 
 `make run-agentics` generates + verifies TS **inside a worktree**. The harness must NOT stop
 there: a feature green only in the worktree that never lands on its target branch is a failed
-delivery. After `build-app`+`test-app` are green, pull the verified files back onto the current
-branch's working tree:
+delivery. Deliver it by **pushing the worktree branch as the PR** — NOT by copying files back into
+the parent working tree (that would re-introduce pollution; ALL artifacts stay in the worktree by
+design — see `openspec-change-worktree-flow`):
 
 ```bash
-make deliver-change CHANGE=<name>     # copies worktree src/main.ts + main.test.ts → repo (file copy, NO commit)
+make openspec-flow NAME=<name> PUSH=1     # creates worktree, archives on green, finalizes, pushes feat/<name> as PR
+# corrections after a pass:
+make openspec-redeliver NAME=<name>        # re-enters worktree, re-squashes, force-pushes to the SAME PR branch (--force-with-lease, never main)
 ```
 
-Never declare a change "done" while its generated TS still lives only in the worktree.
+Never declare a change "done" while its worktree branch (`feat/<name>`) has not been delivered.
+(The earlier `make deliver-change` file-copy directive conflicts with the worktree-confinement
+invariant and is superseded by this PR-push model.)
 
 ---
 
-## 6. Durable behaviours B1–B25 (must always hold, never regress)
+## 6. Durable behaviours B1–B26 (must always hold, never regress)
 
 | ID | Behaviour |
 |----|-----------|
@@ -573,14 +578,15 @@ Never declare a change "done" while its generated TS still lives only in the wor
 | **B9** | Rootless nerdctl bind‑mount permissions (READ+WRITE). Whole repo world‑readable; container write targets world‑writable. Enforced by the `b9-perms` Makefile prerequisite. |
 | **B10** | **NO hard‑coded generated TS/test code in Python** — only contract‑steered. Generated TS bodies live *only* in the change's `tasks.md`/`spec.md` markers; Python only parses + merges + injects verbatim. |
 | **B11** | On generated‑TS failure: **fix the SPEC, then restore, then re‑run** — never edit TS by hand. Bounded ~5‑attempt self‑correct loop; only then may Python floor code be touched as last resort. |
-| **B12** | Delivery gap — verified worktree TS MUST reach the active branch (`make deliver-change`). Never declare done while TS lives only in the worktree. |
+| **B12** | Delivery gap — verified worktree TS MUST reach the target branch as the PR (`make openspec-flow NAME=<name> PUSH=1` → `git push feat/<name>`; corrections via `make openspec-redeliver` force-push to the SAME PR branch). NEVER a file copy into the parent working tree (worktree-confinement invariant). Never declare done while the worktree branch is undelivered. |
 | **B13** | Python *floor* defects are fixed directly, not via spec round‑trips. If the defect is in the deterministic floor itself, fix `CodeIntegratorAgent` — that is the correct spec‑steered fix; only the *merge logic* is corrected, the contract TS body still comes from the spec. |
 | **B14** | Commit/push gating for *new* code (human‑only, behaviour‑scoped). Code is committed ONLY if NEW; pushed ONLY if that new code is part of a behaviour. Floor/integrator Python fixes MAY be committed (and pushed only when part of a committed behaviour) **once**: `build-app`=0, `test-app`=0, passing‑test count **>** previous run, and all OpenSpec checks clean. Rule of thumb: commit only if new AND build works AND tests pass > last run AND OpenSpec clean; push only if that commit is the behaviour landing. **Never squash/rebase/force‑push.** |
 | **B15** | **GitHub issue → local OpenSpec change via the OpenSpec CLI (seed‑then‑generate).** When a change is sourced from a GitHub issue, the agentic code MUST turn it into a local OpenSpec change by **shelling out to `openspec new change ticket<N>`** (the same CLI step a human runs) — never hand‑writing the directory, never a raw `Path.write_text` for the directory shape. `fetch_issue_agent.py` calls `openspec_loader.create_change_from_issue(url, title, body)` after the fetch; that scaffolds via the CLI, fills `proposal.md`/`specs/<cap>/spec.md`/`tasks.md` from the issue, and re‑points generation to `openspec:ticket<N>` so the rest of the loop runs offline. The change name is derived deterministically from the issue URL (`.../issues/20` → `ticket20`), so re‑runs are idempotent. The seeded `openspec/changes/ticket<N>/` is a RUNTIME artifact and MUST NOT be committed (extends B4); `ticket20`/`ticket22` e2e tests generate + clean it up in `finally`. Keeps B10 honest: the exact `openspec new change` a human runs is the one the pipeline runs. |
 | **B16** | **Task‑completion discipline — tick as you verify, never leave open tasks, archive gate fails closed.** `make phase7-archive` runs `openspec_loader.assert_no_open_tasks` BEFORE `openspec archive` and refuses (non‑zero exit, no spec merge) if any `- [ ]` task remains. A change is "done" only when all tasks are ticked AND verified AND archived. `make loop-tasks` lists open/done per change so the backlog is never invisible. |
-| **B17** | **Integration suite is a mandatory loop phase; no dead tests; live tests skip cleanly.** `make loop-harness` runs EIGHT loop stages plus a FINAL B8 doc-sync gate: a collection guard (gate 0), a strict TS test/command floor (gate 0.5), followed by six gates (1–6): `loop-collect` (hermetic collection guard) → `loop-ts-floor` (STRICT TS test/command floor — FAIL if the current branch's `describe`/leaf `it`/`test`/jest-collected/`addCommand` counts drop below `origin/main`) → `loop-unit` (mocked, hermetic) → `loop-unit-real` (REAL agent unit tests on live Ollama, no mocks) → `loop-e2e` (B1/B3 e2e) → `loop-integration` (broad suite) → `loop-build-app` → `loop-test-app`, then `check-docs-sync` (FINAL B8 gate — FAIL if any sync doc drifts on stage order / `loop-ts-floor` / B-range). No dead duplicates; live tests `skipif` cleanly on `OLLAMA_HOST`. |
+| **B17** | **Integration suite is a mandatory loop phase; no dead tests; live tests skip cleanly.** `make loop-harness` runs EIGHT loop stages plus a FINAL B8 doc-sync gate: a collection guard (gate 0), a strict TS test/command floor (gate 0.5), followed by six gates (1–6): `loop-collect` (hermetic collection guard) → `loop-ts-floor` (STRICT TS test/command floor — FAIL if the current branch's `describe`/leaf `it`/`test`/jest-collected/`addCommand` counts drop below `origin/main`) → `loop-unit` (mocked, hermetic) → `loop-unit-real` (REAL agent unit tests on live Ollama, no mocks) → `loop-e2e` (B1/B3 e2e) → `loop-integration` (broad suite) → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` (secret-scanner pytest suite, containerized, real gitleaks, fail-closed; the actual gitleaks tree-scan lives in the pre-commit hook + CI, not the loop), then `check-docs-sync` (FINAL B8 gate — FAIL if any sync doc drifts on stage order / `loop-ts-floor` / B-range). No dead duplicates; live tests `skipif` cleanly on `OLLAMA_HOST`. |
 | **B18** | **Run the agents' REAL unit tests, not only the mocked ones.** The loop MUST execute BOTH the hermetic mocked unit run (`loop-unit` → `test-agents-unit-mock`) AND the real, non‑mocked agent unit run (`loop-unit-real` → `test-agents-unit`, live Ollama) as gates 1 and 2. Reporting "agent tests green" after ONLY the mocked run is INCOMPLETE. `test-agents-unit` MUST be run when Ollama is reachable and its result reported alongside — not instead of — the mocked run. If Ollama is unreachable, `loop-unit-real` SKIPS (must not error) but the agent MUST state the real unit gate did not run. |
 | **B20** | **NEVER declare a change "done" without running the loop gate first — hard pre-flight.** Before claiming any OpenSpec change complete (or "harness green/aligned/fixed"), run the gate and report real output. Preferred: `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`, also `make loop-trigger`) — all eight stages. **HOW TO RUN: long-running `make` targets (`run-agentics`, `build-app`, `test-app`, `loop-harness`, `loop-e2e`, `deliver-change`, `phase7-archive`, `release-flow`) MUST be launched via `terminal(background=true)` — that call executes on the REAL HOST (`/home/asimov/repository/git/projects/obsidian-timestamp-utility`), where `make`/`docker`/rootless `nerdctl`/live Ollama all live. The foreground sandbox (`/workspace`) has NO docker/nerdctl and will say `docker: command not found` — that is EXPECTED and is NOT a blocker; the host has it.** The host provides rootless `nerdctl` AND a live Ollama (host-networked, so `127.0.0.1:11434` reaches it — B19), so `loop-unit-real` and `loop-e2e` are EXPECTED to RUN, not skip. Only STILL run the hermetic gates `make loop-collect` + `make loop-ts-floor` + `make loop-unit` (no external dep) when a stage truly cannot finish in the session; they MUST be green before any "done". Report honestly (PASS/SKIP/FAIL, failing stage named); never claim green if `loop-unit`/`loop-collect` is red; **never claim "can't run from here" — the host runs `make` for you.** Fix root cause and re-run. (B4/B14: no git commit/push from the gate.) |
+| **B26** | **AGENT MAY COMMIT/MERGE ITS OWN CHANGES on a non‑main branch when the PRE‑COMMIT HOOK PASSES.** Permitted to `git commit` (and `git merge`/`git cherry‑pick`) its OWN work‑in‑progress on a feature branch so it can iterate productively. Bounded by: (1) branch guard — current branch MUST NOT be `main`/`origin/main`/protected; (2) hook guard — `git-hooks/pre-commit` (gitleaks + trailing‑whitespace) MUST pass; the agent commits only via the normal `git commit` path, NEVER `--no-verify`. Still forbidden (human‑only): `git push` (B14), `make squash-commits`, `git rebase -i` squash/fixup, `git reset --soft` collapse (B25). Adds commit/merge latitude on feature branches; does NOT lift no‑push/no‑squash/no‑force. (B21–B25 are documented in `AGENTS.md`.) |
 
 ---
 
@@ -714,12 +720,19 @@ Follow the §5.2 self‑correct loop:
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>` → `openspec new change`, per B15) + tasks, validate it, and
-  start the loop — according to the **per-channel trigger**:
+  **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree `feat/<name>`,
+  scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives on green,
+  finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing `feat/<name>`
+  as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER touched
+  (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -737,7 +750,7 @@ This file, `AGENTS.md`, and `hermes/skills/openspec-loop-harness.md` are the **s
 truth**. When you change a behaviour, constraint, command, or pitfall in **any one** of them,
 mirror it in the **other two** before considering the change done:
 
-- Repo authority: `AGENTS.md` (phase flow + B1–B25 summary).
+- Repo authority: `AGENTS.md` (phase flow + B1–B26 summary).
 - Skill mirror: `hermes/skills/openspec-loop-harness.md` (operator‑level detail + pitfalls).
 - This guide: `docs/openspec-engineering-loop-harness.md` (human‑readable technical reference).
 

--- a/tests/fixtures/check_docs_sync/in_sync_en_dash/hermes/skills/openspec-loop-harness.md
+++ b/tests/fixtures/check_docs_sync/in_sync_en_dash/hermes/skills/openspec-loop-harness.md
@@ -24,7 +24,7 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
   walk), (3) **diagnose & correct by fixing the SOURCE OF TRUTH not the symptom** (edit the spec,
   restore, re-run — never hand-edit generated TS, B11; each pass a *different* tweak), and
   (4) **terminate** (bounded ~5 attempts, then escalate to fixing the Python floor B13). Durable
-  invariants B1–B25 are the loop's "laws of physics" that never regress on any pass.
+  invariants B1–B26 are the loop's "laws of physics" that never regress on any pass.
 - **How they fit:** the harness is the **floor** (nothing worse can be written); the loop is the
   **ratchet** (each pass only moves toward green, invariants never slip). Full write-up:
   `docs/openspec-engineering-loop-harness.md` §0.
@@ -181,12 +181,19 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
 - **Request intake gate (front door) — turn inbound requests into OpenSpec changes before acting.**
   Before implementing/answering a new work request, convert it into an OpenSpec change of record
   (`make openspec-new NAME=<derived>` → `openspec new change`, per B15) + tasks, validate it, and
-  start the loop — according to the **per-channel trigger**:
+  **start the worktree flow** — according to the **per-channel trigger**:
   - **Hermes dashboard:** ALWAYS converts by default — no keyword required.
-  - **Telegram:** converts / creates tasks / starts the loop ONLY IF the message contains the
+  - **Telegram:** converts / creates tasks / starts the flow ONLY IF the message contains the
     keyword `openspec` (case-insensitive). Messages without `openspec` are exempt.
-  - **Hermes terminal CLI:** converts / creates tasks / starts the loop ONLY IF the command/text
+  - **Hermes terminal CLI:** converts / creates tasks / starts the flow ONLY IF the command/text
     contains `openspec` (case-insensitive). Requests without `openspec` are exempt.
+  After the change validates, the agent runs `make openspec-flow NAME=<name>` (or
+  `scripts/openspec-change-flow.sh --name <name>`), which creates a dedicated worktree `feat/<name>`,
+  scaffolds the change INSIDE it, generates + runs the loop gate inside it, archives on green,
+  finalizes (squash in the worktree), and — with PUSH=1/`--push` — delivers by pushing `feat/<name>`
+  as the PR. ALL artifacts stay in the worktree; the parent working tree is NEVER touched
+  (B12 override: deliver = PR push, never a file copy). Corrections →
+  `make openspec-redeliver NAME=<name>` (force-pushes to the SAME PR branch).
   Degenerate cases: re-use an in-flight change for the same intent (no duplicate dir); use
   `clarify` first if ambiguous.
   **Kanban-delivery path:** when a request arrives AS a Kanban task (assigned into a kanban
@@ -196,7 +203,7 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
   `docs/openspec-engineering-loop-harness.md` (B8). The reusable directive is the Hermes skill
   `request-to-openspec` (loaded at request entry).
 
-## Durable agent behaviours (B1–B25) — MUST always hold, never regress
+## Durable agent behaviours (B1–B26) — MUST always hold, never regress
 
 These are standing rules for the agent (also in `AGENTS.md`). They are enforced by
 `make phase7-archive` and the persistent harness
@@ -269,7 +276,7 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
   different behaviour. The full B8 sync set (enforced by `make check-docs-sync`, the FINAL loop
   stage) also includes `Makefile`, `docs/openspec-engineering-loop-harness.md`, and
   `scripts/run-loop-harness.sh` — all MUST agree on the 8-stage order + final `check-docs-sync`,
-  the `loop-ts-floor` guard, and the B1–B25 range; a drift there fails the loop.
+  the `loop-ts-floor` guard, and the B1–B26 range; a drift there fails the loop.
 - **(B9) Rootless nerdctl bind-mount permissions (READ + WRITE).** Execution is docker compose
   with **rootless nerdctl**, which remaps the container uid (1000) to the host **`other`** class.
   Every file/dir the container must READ (the whole repo, since compose mounts `..:/project`)
@@ -323,15 +330,17 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
   `_expected_contract_for_change`) only reads the spec contract and merges it deterministically —
   it must never author TS bodies. Hand-editing generated TS is forbidden because it bypasses the
   deterministic merge floor and desyncs the spec from the code.
-- **(B12) Delivery gap — verified worktree TS MUST reach the active branch.** The pipeline
+- **(B12) Delivery gap — verified worktree TS MUST reach the target branch as the PR.** The pipeline
   generates + verifies TS **inside a git worktree** (`worktrees/<name>`, branch `feat/<name>`).
   The harness MUST NOT stop there: a feature green only in the worktree that never lands on its
-  target branch is a failed delivery. After `build-app`+`test-app` are green, the agent MUST pull
-  the verified `src/main.ts` + `src/__tests__/main.test.ts` back onto the **current branch's
-  working tree** (e.g. `make deliver-change CHANGE=<name>` — a file copy, NOT a commit; B4 holds).
-  Never declare a change "done" while its generated TS still lives only in the worktree. (AGENTS.md
-  Phase 5's "old TS remains until you deliberately merge the worktree" previously let verified
-  code die in the worktree — B12 overrides that silence.)
+  target branch is a failed delivery. The agent delivers by **pushing the worktree branch as the PR**
+  (`git push origin feat/<name>`, or `make openspec-flow NAME=<name> PUSH=1`) — it MUST NOT copy
+  generated TS back into the parent working tree (that would re-introduce pollution; ALL artifacts
+  stay in the worktree by design — see `openspec-change-worktree-flow`). Corrections redeliver via
+  `make openspec-redeliver NAME=<name>` (`git push --force-with-lease` to the SAME PR branch only;
+  never `main`). Never declare a change "done" while its worktree branch has not been delivered.
+  (Earlier wording told the agent to `make deliver-change` — a file copy onto the current branch —
+  which conflicts with the worktree-confinement invariant; this override supersedes it.)
 - **(B13) Python *floor* defects are fixed directly, not via spec round-trips.** B11's spec-first
   rule applies when the GENERATED TS/test is wrong. If the defect is in the *deterministic floor*
   itself (e.g. the integrator skips injecting the spec contract when the LLM already emitted a same-
@@ -431,7 +440,7 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
  `127.0.0.1:11434` reaches the live Ollama on the docker host), so they must RUN (not skip) — fix
  root resolution, never add an OLLAMA skip guard. (Closed the gap where `test_greetings_contract_unit.py` + `test_slim_refactor_invariants_unit.py` failed post-archive, and where `test_ticket20/ticket22/greetings` e2e errored on `FileNotFoundError: 'openspec'` due to `/app` root resolution.)
     - **(B20) NEVER declare a change "done" without running the loop gate first — hard pre-flight.** Before claiming any OpenSpec change complete (or "harness green/aligned/fixed"), run the gate and report real output:
-      1. **Preferred:** `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`) — all eight stages: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app`. Also `make loop-trigger`.
+      1. **Preferred:** `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`) — all stages: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-secret-scan-tests` → `check-docs-sync`. Also `make loop-trigger`.
       2. **If full `make loop-harness` can't finish** (live Ollama absent for `loop-e2e`/`loop-unit-real`, or npm build times out), STILL run the hermetic gates `make loop-collect` + `make loop-ts-floor` + `make loop-unit` (no external dep) — they MUST be green before any "done".
       3. **Report honestly:** actual per-stage PASS/SKIP/FAIL with the failing stage named. Never say "done/green" if `loop-unit`/`loop-collect` is red; fix the root cause and re-run. Rationale: the agent previously finished work (incl. AGENTS.md/skill edits) WITHOUT running the gate, leaving `make loop-unit` red. B20 makes the gate mandatory so regressions are caught before "done". (B4/B14: no git commit/push from the gate.)
     - **(B21) HITL is OPT-IN and loop-excluded — never a blocking prompt in automation.** `HITLNode`
@@ -498,6 +507,14 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
       graph. The agent MAY commit (B23) and merge/cherry-pick, but must NOT rewrite/squash existing
       history. If history is messy (leaked throwaway commits), FLAG it for the human and ask — do not
       decide unilaterally. `make squash-commits` is human-triggered only. B8: mirror in AGENTS.md.
+    - **(B26) AGENT MAY COMMIT/MERGE ITS OWN CHANGES on a non-main branch when the PRE-COMMIT HOOK
+      PASSES.** Permitted to `git commit` (and `git merge`/`git cherry-pick`) its OWN work-in-progress
+      on a feature branch so it can iterate productively. Bounded by: (1) branch guard — current
+      branch MUST NOT be `main`/`origin/main`/protected; (2) hook guard — `git-hooks/pre-commit`
+      (gitleaks + trailing-whitespace) MUST pass; the agent commits only via the normal `git commit`
+      path, NEVER `--no-verify`. Still forbidden (human-only): `git push` (B14), `make squash-commits`,
+      `git rebase -i` squash/fixup, `git reset --soft` collapse (B25). Adds commit/merge latitude on
+      feature branches; does NOT lift no-push/no-squash/no-force. B8: mirror in AGENTS.md + harness doc.
     ## Plan-B merge refactor (integrator-merge-refactor)
 
 - **Imports:** inject new `import` lines at the top (after the last existing top-level import).


### PR DESCRIPTION
Throwaway proof of B27 default behaviour: agent works in local wt/<name> sandbox, and on green gates auto-promotes to feat/<name> + opens this PR. Closing as proof only.