### PR TITLE
fix(release): trigger publish on push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ on:
       - main
     types:
       - closed
+  # Also fire on direct pushes to main (e.g. the merge commit of a release fix),
+  # so the fixed release.sh is used even when no new PR close event re-triggers.
+  push:
+    branches:
+      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
release.yml only fired on pull_request:closed, which checks out ref:main (pre-merge). A release fix merged via PR never gets tested by a re-fired run, so 0.4.16 failed to publish. Add push:branches:[main] so the merge commit of a release fix re-triggers the publish with the fixed release.sh.