### PR TITLE
fix(release): install npm deps before build in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install Make
         run: sudo apt-get update && sudo apt-get install -y make
 
+      - name: Install npm dependencies (needed for `npm run build` -> dist/main.js)
+        run: npm ci
+
       - name: Set Version
         id: set_version
         run: |


### PR DESCRIPTION
release.yml installed make but never npm ci, so node_modules was absent. Both the docker build-app (mounts repo) and release.sh's npm run build fallback failed to produce dist/main.js, so release_notes.md was never generated and the publish guard aborted (no 0.4.16 GitHub Release). Add npm ci before the build step.