### PR TITLE
fix(release): release.yml also runs on push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,12 @@ permissions:
 
 jobs:
   build-and-release:
-    # Only release when a PR was actually merged into main.
-    if: github.event.pull_request.merged == true
+    # Release when a PR was merged into main (pull_request closed+merged) OR on a
+    # direct push to main (the merge commit itself). The checkout below uses ref: main,
+    # so on a push event it tests the post-merge main (which contains the fix).
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     env:
       REPO_NAME: obsidian-timestamp-utility


### PR DESCRIPTION
The pull_request:closed trigger checks out pre-merge main, so a release fix could never be exercised by a re-fired run. Allow the job to also run on a direct push to main (the merge commit), which checks out the post-merge main containing the fix.