### PR TITLE
feat(release): hermetic no-publish release-packaging loop gate (B33 B34)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ every spec requirement/scenario); (3) **diagnose & correct by fixing the SOURCE 
 symptom** — edit the OpenSpec spec/contract, restore the generated files to a clean baseline, and
 re-run; NEVER hand-edit generated TS (B11), and each pass must try a *different* correction; and
 (4) **terminate** — a bounded ~5 attempts with a clear escalation (fix the Python floor as a last
-resort, B13). The durable behaviours B1–B32 are the loop's "laws of physics" — invariants that
+resort, B13). The durable behaviours B1–B34 are the loop's "laws of physics" — invariants that
 never regress on any pass (permanent e2e B1–B6, no-commit/no-push gate B4/B14, delivery step B12).
 
 **How they fit:** the harness is the **floor** (nothing worse than the contract can ever be
@@ -402,7 +402,7 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
  coordinate `127.0.0.1:11434` reaches the live Ollama on the docker host), so they must RUN (not
  skip) — root resolution is the actual bug to fix, not a skip guard.
   - **(B20) NEVER declare a change "done" without running the loop gate first — this is a hard pre-flight, not optional.** Before reporting any OpenSpec change as complete (or before claiming "the harness is green / aligned / fixed"), the agent MUST execute the loop gate and report its real output:
-      1. **Preferred:** run `bash scripts/run-loop-harness.sh` (the loop-harness runner — it streams each stage's container/pytest/jest output to the terminal LIVE, prints a start banner + heartbeat on quiet stages, and ends with a per-stage PASS/FAIL/timeout summary; it wraps `make <stage>` in `setsid script … | tee` so nerdctl's forced `--tty` gets a console without deadlocking under an interactive shell). It runs all stages in order: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-release-tests` → `loop-secret-scan-tests` → `check-docs-sync`. (The standalone `make test-agents-*` / `make run-agentics` commands also self-provide a console via the Makefile `$(call docker_run, …)` helper, which uses `script` only when stdout is not a tty.)
+      1. **Preferred:** run `bash scripts/run-loop-harness.sh` (the loop-harness runner — it streams each stage's container/pytest/jest output to the terminal LIVE, prints a start banner + heartbeat on quiet stages, and ends with a per-stage PASS/FAIL/timeout summary; it wraps `make <stage>` in `setsid script … | tee` so nerdctl's forced `--tty` gets a console without deadlocking under an interactive shell). It runs all stages in order: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-release-dryrun` → `loop-release-tests` → `loop-secret-scan-tests` → `check-docs-sync`. (The standalone `make test-agents-*` / `make run-agentics` commands also self-provide a console via the Makefile `$(call docker_run, …)` helper, which uses `script` only when stdout is not a tty.)
          **HOW TO RUN (never make excuses):** long-running `make` targets (`run-agentics`, `build-app`, `test-app`, `loop-harness`, `loop-e2e`, `deliver-change`, `phase7-archive`, `release-flow`) MUST be launched via `terminal(background=true)` — that call executes on the **REAL HOST** (`/home/asimov/repository/git/projects/obsidian-timestamp-utility`), where `make`/`docker`/rootless `nerdctl`/live Ollama all live. The foreground sandbox (`/workspace`) has NO docker/nerdctl and will print `docker: command not found` — that is EXPECTED and is NOT a blocker; the host has it. **Never say "can't run from here" / "environment absent" — the host runs `make` for you.** Drive verification through `make` with REAL output, always.
       2. **If the full `make loop-harness` cannot complete in the session** (e.g. an explicit
          timeout, or a stage is deliberately disabled via env), the agent MUST STILL run the
@@ -665,7 +665,7 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
   - **(B31) MAKE-THROUGH-DOCKER IS ALWAYS A BACKGROUND PROCESS — NEVER THE FOREGROUND SANDBOX.** Every Makefile target that invokes a container runtime (any `docker`, `nerdctl`, or `*compose*` binary via `$(call docker_run, …)`) MUST be executed through the Hermes `terminal(background=true)` channel, which runs on the **real host** that owns the docker/nerdctl daemon and the live Ollama. The foreground sandbox (`/workspace`) has NO container runtime and MUST NOT be used for these targets. This is mandatory for ANY such target — not merely the long-running ones (run-agentics, build-app, test-app, loop-harness, loop-e2e, deliver-change, phase7-archive, release-flow) but also short ones (loop-collect, loop-ts-floor, loop-unit, test-agents-unit, test-agents-integration, verify-agentics-after-run).
     1. **The host is the only supported docker path.** The foreground sandbox returns `docker: command not found` — that is EXPECTED and is NOT a blocker; the host has the daemon. The agent MUST route the target through `terminal(background=true)` and MUST NOT report "can't run from here" / "environment absent".
     2. **No silent foreground runs.** A `make <docker-backed-target>` issued from the foreground terminal is re-dispatched to the background host; the agent never lets it fail on a missing daemon in the sandbox.
-    3. **B8 sync.** This behaviour is recorded in the B8 doc-sync set (AGENTS.md, `hermes/skills/openspec-loop-harness.md`, `docs/openspec-engineering-loop-harness.md`, `Makefile`, `scripts/run-loop-harness.sh`) with the B-range string `B1–B31` so `check-docs-sync` stays green.
+    3. **B8 sync.** This behaviour is recorded in the B8 doc-sync set (AGENTS.md, `hermes/skills/openspec-loop-harness.md`, `docs/openspec-engineering-loop-harness.md`, `Makefile`, `scripts/run-loop-harness.sh`) with the B-range string `B1–B34` so `check-docs-sync` stays green.
      B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md` and `docs/openspec-engineering-loop-harness.md` (B8).
      B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md` and
      `docs/openspec-engineering-loop-harness.md`.
@@ -693,6 +693,31 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
      once they have approved, the owner wants tidy single-commit history for merge. `loop-final` is
      the human-gated, gate-verified bridge between those two states. (B31 is the concurrent
      `make-always-background` change / PR #58; this behaviour is B32.)
+     B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md` and
+     `docs/openspec-engineering-loop-harness.md`.
+  - **(B33) RELEASE PACKAGING IS A HERMETIC, NO-PUBLISH DOCKER+MAKE LOOP GATE.** The release
+     artifact set MUST be verified on every loop run WITHOUT calling the GitHub release API. The
+     gate `make loop-release-dryrun` runs through docker + make: it builds the plugin (`make
+     build-app`, the `containers/npm` node image where rollup + its plugins are installed),
+     runs the plugin jest tests (`make test-app`), then runs `scripts/release.sh` in `DRY_RUN=1`
+     and ASSERTS the produced `<REPO_NAME>-<TAG>.zip` contains the compiled `main.js` (and that
+     `release/main.js` is non-empty). The loop MUST NOT go green while that gate fails. This is
+     the regression guard for the 0.4.16 defect (a published release whose zip shipped without
+     the compiled plugin). `scripts/release.sh` is PACKAGING-ONLY — it assumes `dist/main.js`
+     already exists (built by `make build-app`) and must NOT rebuild inline; `make release`
+     depends on `build-app` so the plugin is always compiled before packaging. No GitHub API
+     call happens in the loop gate (B14). The `release.yml` CI workflow still publishes on merge
+     to main; this gate only proves, locally and hermetically, that the packaging would be valid.
+     B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md` and
+     `docs/openspec-engineering-loop-harness.md`.
+  - **(B34) NO MERGE / NO FORCE-PUSH UNTIL THE HUMAN APPROVES VIA A PR COMMENT.** A PR opened by
+     the agent (delivery of an OpenSpec change) MUST NOT be merged, squashed, or force-pushed by
+     the agent until the human has EXPLICITLY approved it through a comment on that PR (e.g.
+     "approved", "lgtm", "merge it"). The agent opens/redelivers the PR, then WAITS for the
+     approval comment; it must not auto-merge on "green" alone (this overrides the older
+     auto-promote-on-green behaviour). This is the standing review gate: the human holds the
+     merge decision. B32's `loop-final APPROVED=1` is the ONLY sanctioned finalisation and still
+     requires an explicit human approval phrase first.
      B8 sync: mirrored in `hermes/skills/openspec-loop-harness.md` and
      `docs/openspec-engineering-loop-harness.md`.
   - **(B7.1) The deterministic floor runs in EVERY mode (incl. fast).** `route_hitl` in
@@ -790,8 +815,8 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
   stage order, the `loop-ts-floor` guard, or the B-behaviour range:
   1. **`Makefile`** — the executable gates + canonical stage-order comment; `make loop-harness`
      runs `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e`
-           → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-release-tests` → `loop-secret-scan-tests` → `check-docs-sync` (final).
-  2. **`AGENTS.md`** — this file: the authoritative narrative + the B1–B32 durable behaviours.
+           → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-release-dryrun` → `loop-release-tests` → `loop-secret-scan-tests` → `check-docs-sync` (final).
+  2. **`AGENTS.md`** — this file: the authoritative narrative + the B1–B34 durable behaviours.
   3. **`hermes/skills/openspec-loop-harness.md`** — the loadable skill mirror of AGENTS.md.
   4. **`docs/openspec-engineering-loop-harness.md`** — the human-readable technical reference
      (named by B8 itself as authoritative; MUST be kept in the sync set, not treated as a 4th
@@ -804,7 +829,7 @@ These behaviours are encoded in `hermes/skills/openspec-loop-harness.md` and enf
   Before claiming "the loop is green / aligned", run `make check-docs-sync` (the final loop stage)
   and confirm it PASSES: all sync docs agree on the 11-stage order (loop-collect → loop-ts-floor →
   loop-unit → loop-unit-real → loop-e2e → loop-integration → loop-build-app → loop-test-app →
-  loop-release-tests → loop-secret-scan-tests → check-docs-sync), the `loop-ts-floor` guard, the B1–B32 behaviours, and
+  loop-release-tests → loop-secret-scan-tests → check-docs-sync), the `loop-ts-floor` guard, the B1–B34 behaviours, and
   the live-test skip rule (`OLLAMA_HOST` only, not `GITHUB_TOKEN`). A change is NOT done while any
   of the sync docs disagree.
   - **(B17a) ROOT `tests/` FOLDER IS PART OF THE LOOP.** Beyond `agents/agentics/tests/` (unit /

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ DOCKER_SOCK := $(shell \
         collect-tests collect-executed generate-requirements \
         stop-containers \
         clean clean-cache clean-logs clean-oci \
-        loop-harness loop-collect loop-ts-floor loop-unit loop-unit-real loop-e2e loop-integration loop-build-app loop-test-app loop-verify loop-tasks \
+        loop-harness loop-collect loop-ts-floor loop-unit loop-unit-real loop-e2e loop-integration loop-build-app loop-test-app loop-release-dryrun loop-release-tests loop-verify loop-tasks \
         wt-create openspec-flow openspec-redeliver \
         squash-commits \
         squash-commits bump-version release-notes tag-release loop-release check-released release bump-local release-prep \
@@ -158,9 +158,14 @@ bump-from-changelog: b9-perms ## Rename '## Unreleased' -> next version (anchore
 	$(call docker_run, docker compose -f docker-compose-files/agents.yaml run --rm -e GIT_CONFIG_GLOBAL=/tmp/gitconfig unit-test-agents sh -c "cd /project && git config --global --add safe.directory /project && python3 /project/scripts/bump_from_changelog.py") || echo "bump-from-changelog skipped"
 	@$(MAKE) changelog-format
 
-release: clean ## Create release + ZIP check (wires scripts/release.sh which generates release_notes.md + the downloadable zip)
+# `release` depends on `build-app` (the containers/npm node image builds dist/main.js via
+# rollup, which has the rollup plugins installed — this is what was missing in CI when
+# release.sh tried to build inline). release.sh is PACKAGING-ONLY: it assumes dist/main.js
+# exists and assembles notes + zip. DRY_RUN=1 still skips the GitHub publish, but the
+# artifacts are always built + packaged.
+release: build-app ## Create release + ZIP (build-app first, then scripts/release.sh packages notes + zip)
 	@if [ -z "$(TAG)" ]; then TAG=$$(node -p "require('./package.json').version"); fi; \
-	 echo "=== release: building artifacts via scripts/release.sh (TAG=$$TAG) ==="; \
+	 echo "=== release: packaging artifacts via scripts/release.sh (TAG=$$TAG) ==="; \
 	 TAG="$$TAG" REPO_NAME="$(REPO_NAME)" DRY_RUN="$(DRY_RUN)" bash scripts/release.sh
 	@echo "Release zip: $(REPO_NAME)-$(TAG).zip"
 
@@ -293,16 +298,16 @@ run-agentics: b9-perms ## Run AI agentics on a LOCAL OpenSpec change (CHANGE=<na
 #        7. secret-scan-tests  (loop-secret-scan-tests) -- secret-scanner pytest suite, containerized (B9), real gitleaks, fail-closed
 #           (the actual gitleaks tree-scan lives in the pre-commit hook + CI, not the loop)
 #        8. doc-sync          (check-docs-sync) -- FINAL B8 gate: FAIL if any sync doc drifts (stage order / loop-ts-floor / B-range)
-#      B8 durable-behaviour range: B1-B32 (the loop's "laws of physics"; see AGENTS.md). The
+#      B8 durable-behaviour range: B1-B34 (the loop's "laws of physics"; see AGENTS.md). The
 #      Canonical stage order (B8 source of truth):
-#        loop-collect -> loop-ts-floor -> loop-unit -> loop-unit-real -> loop-e2e -> loop-integration -> loop-build-app -> loop-test-app -> loop-release-tests -> loop-secret-scan-tests -> check-docs-sync
-#      Durable behaviours span B1-B32 (the loop's "laws of physics"); this doc-sync gate FAILS if any sync doc drifts on that order / loop-ts-floor / the B1-B32 range.
+#        loop-collect -> loop-ts-floor -> loop-unit -> loop-unit-real -> loop-e2e -> loop-integration -> loop-build-app -> loop-test-app -> loop-release-dryrun -> loop-release-tests -> loop-secret-scan-tests -> check-docs-sync
+#      Durable behaviours span B1-B34 (the loop's "laws of physics"); this doc-sync gate FAILS if any sync doc drifts on that order / loop-ts-floor / the B1-B34 range.
 #      `make check-docs-sync` is the FINAL loop stage (enforced, not advisory) so doc/loop drift
 #      fails the whole run (B8 enforced).
 #      Each stage fails the whole run if it fails (no silent green). No git commit/push
 #      (B4/B14). Optional post-check: `make loop-verify CHANGE=<name>` runs openspec
 #      validate + status for the active change.
-check-docs-sync: b9-perms ## B8 doc/loop sync gate (FINAL loop stage) — FAIL if any B8 source-of-truth doc drifts (stage order / loop-ts-floor / B-range B1-B32). Runs INSIDE unit-test-agents (no host python3).
+check-docs-sync: b9-perms ## B8 doc/loop sync gate (FINAL loop stage) — FAIL if any B8 source-of-truth doc drifts (stage order / loop-ts-floor / B-range B1-B34). Runs INSIDE unit-test-agents (no host python3).
 	@echo "=== B8 DOC-SYNC: verify loop/loop-harness docs agree (stage order, loop-ts-floor, B-range) — in container ==="
 	@$(call docker_run, docker compose -f docker-compose-files/agents.yaml run --rm unit-test-agents sh -c "cd /project && python3 /project/scripts/check-docs-sync.py")
 
@@ -342,13 +347,25 @@ loop-release-tests: b9-perms ## Loop gate 6.5: release-pipeline + README-sync dr
 	@echo "=== LOOP-HARNESS [6.5] release-pipeline + README-sync dry-run tests ==="
 	@$(call docker_run, docker compose -f docker-compose-files/agents.yaml run --rm -e DRY_RUN=1 -e GIT_CONFIG_GLOBAL=/tmp/gitconfig unit-test-agents sh -c "cd /project && DRY_RUN=1 python -m pytest tests/test_release_pipeline_dryrun.py tests/test_readme_sync.py tests/test_release_notes_bump.py -v")
 
+loop-release-dryrun: ## Loop gate 6.7: RELEASE PACKAGING dry-run, hermetic, NO publish (B33). Builds the plugin via build-app (containers/npm node image, rollup + plugins installed), runs jest (test-app), then runs scripts/release.sh in DRY_RUN=1 and ASSERTS the produced zip contains the compiled main.js. Never calls the GitHub release API. This is the gate that proves a real release would ship a usable plugin (the 0.4.16 defect).
+	@echo "=== LOOP-HARNESS [6.7] release-packaging dry-run (build-app -> test-app -> release.sh DRY_RUN=1 -> assert main.js in zip) ==="
+	@$(MAKE) build-app
+	@$(MAKE) test-app
+	@echo "=== release dry-run: packaging via scripts/release.sh (DRY_RUN=1) ==="
+	@$(call docker_run, docker compose -f docker-compose-files/tools.yaml run --rm app bash -c "set -e; export REPO_NAME=obsidian-timestamp-utility; export TAG=\$$(node -p \"require('./package.json').version\"); export DRY_RUN=1; bash scripts/release.sh; \\
+	  echo '--- asserting zip contains main.js ---'; \\
+	  unzip -l \"\$${REPO_NAME}-\$${TAG}.zip\" | grep -q 'main.js' || { echo 'FAIL: zip missing main.js'; exit 1; }; \\
+	  echo 'OK: zip contains main.js'; \\
+	  test -s release/main.js && echo 'OK: release/main.js non-empty'")
+	@echo "=== LOOP-HARNESS [6.7] release-packaging dry-run GREEN (no GitHub call) ==="
+
 loop-harness: ## Full loop-harness: SINGLE source of truth = scripts/run-loop-harness.sh.
 	@# This target delegates to the script so the per-stage timeouts + docker-kill
 	@# logic are ALWAYS applied (never a bare `make` chain that can hang forever).
 	@# The script calls back into these same `loop-*` targets, so what runs is
 	@# identical whether you invoke `make loop-harness` or the script directly.
 	@bash scripts/run-loop-harness.sh
-	@echo "=== LOOP-HARNESS COMPLETE: all gates green in order (collect -> ts-floor -> unit -> unit-real -> e2e -> integration -> build-app -> test-app -> release-tests -> secret-scan-tests -> check-docs-sync) ==="
+	@echo "=== LOOP-HARNESS COMPLETE: all gates green in order (collect -> ts-floor -> unit -> unit-real -> e2e -> integration -> build-app -> test-app -> release-dryrun -> release-tests -> secret-scan-tests -> check-docs-sync) ==="
 
 loop-trigger: ## B20 mandatory pre-flight: run the loop gate (scripts/run-loop-harness.sh) before claiming done
 	@bash scripts/run-loop-harness.sh

--- a/containers/agents/Dockerfile
+++ b/containers/agents/Dockerfile
@@ -7,8 +7,8 @@ FROM python:3.10-slim AS base
 # Install Node.js 22.x and npm
 RUN apt-get update && apt-get install -y curl && \
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get install -y nodejs git && \
-    node --version && npm --version && \
+    apt-get install -y nodejs git zip unzip && \
+    node --version && npm --version && zip --version && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install TypeScript globally for use by agents that require it

--- a/docs/openspec-engineering-loop-harness.md
+++ b/docs/openspec-engineering-loop-harness.md
@@ -8,7 +8,7 @@
 > 2. **Harness engineering** — the Python "agentics" pipeline (`agents/agentics/`) and
 >    the deterministic merge floor that writes your `src/main.ts` / `src/__tests__/main.test.ts`.
 > 3. **Loop engineering** — the bounded self‑correcting build→test→fix loop and the
->    durable behaviours **B1–B32** that the loop must always honour.
+>    durable behaviours **B1–B34** that the loop must always honour.
 >
 > It also documents the **file structure**, every file that creates the harness's
 > behaviour, and a **how‑to‑use** walkthrough for authoring a new feature.
@@ -21,7 +21,7 @@ at repo root, the previous `docs/openspec-loop-harness-guide.md`) are historical
 ## 0. Fundamentals — what "harness" and "loop" engineering mean
 
 Before the technical detail, understand the two disciplines this whole system is built on.
-Everything below (OpenSpec, the Python pipeline, the Makefile, B1–B32) is just a concrete
+Everything below (OpenSpec, the Python pipeline, the Makefile, B1–B34) is just a concrete
 implementation of these two ideas. If you internalise this section, the rest of the document
 reads as "here is *how* we do harness + loop engineering in this repo."
 
@@ -91,7 +91,7 @@ A well‑engineered loop has four parts:
    a loop with no escalation hides real defects.
 
 The loop is also where **durability** lives: the invariants that must hold on *every* pass
-(B1–B32) — a permanent regression e2e that outlives every feature (B1–B6), the no‑commit/no‑push
+(B1–B34) — a permanent regression e2e that outlives every feature (B1–B6), the no‑commit/no‑push
 gate (B4/B14), the delivery step that moves verified code out of the worktree onto the branch
 (B12). These are the loop's "laws of physics": conditions that never regress no matter how many
 times you go round.
@@ -105,7 +105,7 @@ gate is green, then stop."
 | Discipline | Job | Answers the question | In this repo |
 |-----------|-----|----------------------|--------------|
 | **Harness engineering** | *Constrain* the generator into a verifiable shape | "How do I make one generation trustworthy?" | OpenSpec contract as source of truth + `CodeIntegratorAgent` deterministic merge floor + omission guard + B9 perms + git‑HEAD restore |
-| **Loop engineering** | *Correct* the generator across attempts until an objective gate passes | "How do I make the system converge on correct, and know when to stop?" | `make build-app`/`make test-app` gate + spec‑first self‑correct loop (bounded ~5) + durable behaviours B1–B32 + delivery step B12 |
+| **Loop engineering** | *Correct* the generator across attempts until an objective gate passes | "How do I make the system converge on correct, and know when to stop?" | `make build-app`/`make test-app` gate + spec‑first self‑correct loop (bounded ~5) + durable behaviours B1–B34 + delivery step B12 |
 
 The harness is the **floor** (nothing worse than this can be written); the loop is the **ratchet**
 (each pass can only move toward green, and the invariants never slip back). The rest of this
@@ -148,7 +148,7 @@ Three non‑negotiable principles:
 
 ```
 obsidian-timestamp-utility/
-├── AGENTS.md                         # Repo‑level authority: phase flow + B1–B32 summary
+├── AGENTS.md                         # Repo‑level authority: phase flow + B1–B34 summary
 ├── Makefile                          # ALL execution entry points (docker compose only, no Dagger)
 ├── docker-compose-files/
 │   ├── agents.yaml                   # agentics / unit‑test‑agents / integration‑test‑agents services
@@ -584,7 +584,7 @@ reviewer engagement, corrections land as normal commits, never squashed).
 
 ---
 
-## 6. Durable behaviours B1–B32 (must always hold, never regress)
+## 6. Durable behaviours B1–B34 (must always hold, never regress)
 
 | ID | Behaviour |
 |----|-----------|
@@ -604,7 +604,7 @@ reviewer engagement, corrections land as normal commits, never squashed).
 | **B14** | Commit/push gating for *new* code (human‑only, behaviour‑scoped). Code is committed ONLY if NEW; pushed ONLY if that new code is part of a behaviour. Floor/integrator Python fixes MAY be committed (and pushed only when part of a committed behaviour) **once**: `build-app`=0, `test-app`=0, passing‑test count **>** previous run, and all OpenSpec checks clean. Rule of thumb: commit only if new AND build works AND tests pass > last run AND OpenSpec clean; push only if that commit is the behaviour landing. **Never squash/rebase/force‑push.** |
 | **B15** | **GitHub issue → local OpenSpec change via the OpenSpec CLI (seed‑then‑generate).** When a change is sourced from a GitHub issue, the agentic code MUST turn it into a local OpenSpec change by **shelling out to `openspec new change ticket<N>`** (the same CLI step a human runs) — never hand‑writing the directory, never a raw `Path.write_text` for the directory shape. `fetch_issue_agent.py` calls `openspec_loader.create_change_from_issue(url, title, body)` after the fetch; that scaffolds via the CLI, fills `proposal.md`/`specs/<cap>/spec.md`/`tasks.md` from the issue, and re‑points generation to `openspec:ticket<N>` so the rest of the loop runs offline. The change name is derived deterministically from the issue URL (`.../issues/20` → `ticket20`), so re‑runs are idempotent. The seeded `openspec/changes/ticket<N>/` is a RUNTIME artifact and MUST NOT be committed (extends B4); `ticket20`/`ticket22` e2e tests generate + clean it up in `finally`. Keeps B10 honest: the exact `openspec new change` a human runs is the one the pipeline runs. |
 | **B16** | **Task‑completion discipline — tick as you verify, never leave open tasks, archive gate fails closed.** `make phase7-archive` runs `openspec_loader.assert_no_open_tasks` BEFORE `openspec archive` and refuses (non‑zero exit, no spec merge) if any `- [ ]` task remains. A change is "done" only when all tasks are ticked AND verified AND archived. `make loop-tasks` lists open/done per change so the backlog is never invisible. |
-| **B17** | **Integration suite is a mandatory loop phase; no dead tests; live tests skip cleanly.** `make loop-harness` runs TEN loop stages plus a FINAL B8 doc-sync gate: a collection guard (gate 0), a strict TS test/command floor (gate 0.5), followed by six gates (1–6): `loop-collect` (hermetic collection guard) → `loop-ts-floor` (STRICT TS test/command floor — FAIL if the current branch's `describe`/leaf `it`/`test`/jest-collected/`addCommand` counts drop below `origin/main`) → `loop-unit` (mocked, hermetic) → `loop-unit-real` (REAL agent unit tests on live Ollama, no mocks) → `loop-e2e` (B1/B3 e2e) → `loop-integration` (broad suite) → `loop-build-app` → `loop-test-app` → `loop-release-tests` (release-pipeline dry-run tests from the root `tests/` folder, `DRY_RUN=1`, no GitHub calls) → `loop-secret-scan-tests` (secret-scanner pytest suite, containerized, real gitleaks, fail-closed; the actual gitleaks tree-scan lives in the pre-commit hook + CI, not the loop), then `check-docs-sync` (FINAL B8 gate — FAIL if any sync doc drifts on stage order / `loop-ts-floor` / B-range). No dead duplicates; live tests `skipif` cleanly on `OLLAMA_HOST`. |
+| **B17** | **Integration suite is a mandatory loop phase; no dead tests; live tests skip cleanly.** `make loop-harness` runs TEN loop stages plus a FINAL B8 doc-sync gate: a collection guard (gate 0), a strict TS test/command floor (gate 0.5), followed by six gates (1–6): `loop-collect` (hermetic collection guard) → `loop-ts-floor` (STRICT TS test/command floor — FAIL if the current branch's `describe`/leaf `it`/`test`/jest-collected/`addCommand` counts drop below `origin/main`) → `loop-unit` (mocked, hermetic) → `loop-unit-real` (REAL agent unit tests on live Ollama, no mocks) → `loop-e2e` (B1/B3 e2e) → `loop-integration` (broad suite) → `loop-build-app` → `loop-test-app` → `loop-release-dryrun` (release-packaging dry-run: builds the plugin via `make build-app`, runs jest via `make test-app`, then runs `scripts/release.sh` DRY_RUN=1 and asserts the zip contains `main.js` — hermetic, no GitHub publish; the 0.4.16 regression guard, B33) → `loop-release-tests` (release-pipeline dry-run tests from the root `tests/` folder, `DRY_RUN=1`, no GitHub calls) → `loop-secret-scan-tests` (secret-scanner pytest suite, containerized, real gitleaks, fail-closed; the actual gitleaks tree-scan lives in the pre-commit hook + CI, not the loop), then `check-docs-sync` (FINAL B8 gate — FAIL if any sync doc drifts on stage order / `loop-ts-floor` / B-range). No dead duplicates; live tests `skipif` cleanly on `OLLAMA_HOST`. |
 | **B18** | **Run the agents' REAL unit tests, not only the mocked ones.** The loop MUST execute BOTH the hermetic mocked unit run (`loop-unit` → `test-agents-unit-mock`) AND the real, non‑mocked agent unit run (`loop-unit-real` → `test-agents-unit`, live Ollama) as gates 1 and 2. Reporting "agent tests green" after ONLY the mocked run is INCOMPLETE. `test-agents-unit` MUST be run when Ollama is reachable and its result reported alongside — not instead of — the mocked run. If Ollama is unreachable, `loop-unit-real` SKIPS (must not error) but the agent MUST state the real unit gate did not run. |
 | **B20** | **NEVER declare a change "done" without running the loop gate first — hard pre-flight.** Before claiming any OpenSpec change complete (or "harness green/aligned/fixed"), run the gate and report real output. Preferred: `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`, also `make loop-trigger`) — all ten stages. **HOW TO RUN: long-running `make` targets (`run-agentics`, `build-app`, `test-app`, `loop-harness`, `loop-e2e`, `deliver-change`, `phase7-archive`, `release-flow`) MUST be launched via `terminal(background=true)` — that call executes on the REAL HOST (`/home/asimov/repository/git/projects/obsidian-timestamp-utility`), where `make`/`docker`/rootless `nerdctl`/live Ollama all live. The foreground sandbox (`/workspace`) has NO docker/nerdctl and will say `docker: command not found` — that is EXPECTED and is NOT a blocker; the host has it.** The host provides rootless `nerdctl` AND a live Ollama (host-networked, so `127.0.0.1:11434` reaches it — B19), so `loop-unit-real` and `loop-e2e` are EXPECTED to RUN, not skip. Only STILL run the hermetic gates `make loop-collect` + `make loop-ts-floor` + `make loop-unit` (no external dep) when a stage truly cannot finish in the session; they MUST be green before any "done". Report honestly (PASS/SKIP/FAIL, failing stage named); never claim green if `loop-unit`/`loop-collect` is red; **never claim "can't run from here" — the host runs `make` for you.** Fix root cause and re-run. (B4/B14: no git commit/push from the gate.) |
 | **B26** | **AGENT MAY COMMIT AND PUSH ITS OWN CHANGES on a non‑main branch when the LOOP GATE IS GREEN and the PRE‑COMMIT HOOK PASSES.** Permitted to `git commit` (and `git merge`/`git cherry‑pick`, and `git push` to its OWN feature/PR branch) its OWN work‑in‑progress so the remote stays synced. Bounded by: (1) branch guard — current branch MUST NOT be `main`/`origin/main`/protected; (2) hook guard — `git-hooks/pre-commit` (gitleaks + trailing‑whitespace) MUST pass; the agent commits only via the normal `git commit` path, NEVER `--no-verify`; (3) loop‑gate guard — push ONLY after the OpenSpec/loop gate is GREEN for the change (build‑app=0 + test‑app pass, and/or `check-docs-sync` PASS for doc‑only changes), never push red work; (4) still forbidden (human‑only): `git push` to main (B14), `make squash-commits`, `git rebase -i` squash/fixup, `git reset --soft` collapse (B25). Adds commit/merge/**push‑to‑own‑branch** latitude on feature branches; does NOT lift no‑push‑to‑main/no‑squash/no‑force. |
@@ -621,6 +621,8 @@ reviewer engagement, corrections land as normal commits, never squashed).
 ---
 
 | **B32** | **`loop-final` — REVIEW‑APPROVED SQUASH + CHANGELOG + FORCE‑PUSH.** The ONE sanctioned exit from B28a/B30b (B31 = the concurrent `make-always-background` change / PR #58). The default (no approval) STANDS: the agent never squashes/force‑pushes an open PR on its own. Once a human REVIEWS + EXPLICITLY APPROVES the PR (a phrase such as "PR looks great" / "looks good" / "approved to finalize"), the agent runs `make loop-final BRANCH=<feat/...> APPROVED=1`, which: (1) **B32a Human‑approval gate:** fails closed unless `APPROVED=1` — the agent sets it ONLY in direct response to a human approval phrase, never in automation. (2) **B32b Fresh green loop‑harness first:** runs a FRESH `make loop-harness` and ABORTS (no squash, no force‑push) if any stage is not green — history is NEVER rewritten on a red gate (B30c still holds). (3) **B32c Squash + changelog on green:** `squash-commits ALLOW_SQUASH=1` (the B30d sanctioned override) → `changelog` → `bump-from-changelog` → `changelog-format`, regenerating the CHANGELOG from the single squashed typed commit. (4) **B32d `--force-with-lease` feature branch only:** refuses `main`/`origin/main`; force is `--force-with-lease` only. (5) **B32e B30a stays absolute:** `git revert` is still never allowed — `loop-final` is a forward finalisation, not a revert. Rationale: the reviewer needs a stable incremental diff DURING review (B28a/B30b); once approved, the owner wants tidy single‑commit history for merge, and `loop-final` is the human‑gated, gate‑verified bridge between those states. |
+| **B33** | **RELEASE PACKAGING IS A HERMETIC, NO-PUBLISH DOCKER+MAKE LOOP GATE.** The release artifact set MUST be verified on every loop run WITHOUT calling the GitHub release API. The gate `make loop-release-dryrun` runs through docker + make: builds the plugin (`make build-app`, the `containers/npm` node image where rollup + its plugins are installed), runs the plugin jest tests (`make test-app`), then runs `scripts/release.sh` in `DRY_RUN=1` and ASSERTS the produced `<REPO_NAME>-<TAG>.zip` contains the compiled `main.js` (and `release/main.js` is non-empty). The loop MUST NOT go green while that gate fails — it is the regression guard for the 0.4.16 defect (a published release whose zip shipped without the compiled plugin). `scripts/release.sh` is PACKAGING-ONLY (assumes `dist/main.js` built by `make build-app`; must NOT rebuild inline); `make release` depends on `build-app` so the plugin is always compiled before packaging. No GitHub API call in the loop gate (B14). The `release.yml` CI workflow still publishes on merge to main; this gate only proves, locally and hermetically, that the packaging would be valid. |
+| **B34** | **NO MERGE / NO FORCE-PUSH UNTIL THE HUMAN APPROVES VIA A PR COMMENT.** A PR opened by the agent MUST NOT be merged, squashed, or force-pushed until the human has EXPLICITLY approved it through a comment on that PR (e.g. "approved" / "lgtm" / "merge it"). The agent opens/redelivers the PR, then WAITS for the approval comment; it must not auto-merge on "green" alone (this overrides the older auto-promote-on-green behaviour — B27 auto-delivery still opens the PR, but the MERGE waits for human approval). The human holds the merge decision. B32 `loop-final APPROVED=1` is still the only sanctioned finalisation and still requires an explicit human approval phrase first. |
 ---
 
 ## 7. How to use it (authoring a new feature)
@@ -784,7 +786,7 @@ This file, `AGENTS.md`, and `hermes/skills/openspec-loop-harness.md` are the **s
 truth**. When you change a behaviour, constraint, command, or pitfall in **any one** of them,
 mirror it in the **other two** before considering the change done:
 
-- Repo authority: `AGENTS.md` (phase flow + B1–B32 summary).
+- Repo authority: `AGENTS.md` (phase flow + B1–B34 summary).
 - Skill mirror: `hermes/skills/openspec-loop-harness.md` (operator‑level detail + pitfalls).
 - This guide: `docs/openspec-engineering-loop-harness.md` (human‑readable technical reference).
 

--- a/hermes/skills/openspec-loop-harness.md
+++ b/hermes/skills/openspec-loop-harness.md
@@ -24,7 +24,7 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
   walk), (3) **diagnose & correct by fixing the SOURCE OF TRUTH not the symptom** (edit the spec,
   restore, re-run — never hand-edit generated TS, B11; each pass a *different* tweak), and
   (4) **terminate** (bounded ~5 attempts, then escalate to fixing the Python floor B13). Durable
-  invariants B1–B32 are the loop's "laws of physics" that never regress on any pass.
+  invariants B1–B34 are the loop's "laws of physics" that never regress on any pass.
 - **How they fit:** the harness is the **floor** (nothing worse can be written); the loop is the
   **ratchet** (each pass only moves toward green, invariants never slip). Full write-up:
   `docs/openspec-engineering-loop-harness.md` §0.
@@ -203,7 +203,7 @@ The whole system is a concrete implementation of two disciplines. Grasp these be
   `docs/openspec-engineering-loop-harness.md` (B8). The reusable directive is the Hermes skill
   `request-to-openspec` (loaded at request entry).
 
-## Durable agent behaviours (B1–B32) — MUST always hold, never regress
+## Durable agent behaviours (B1–B34) — MUST always hold, never regress
 
 These are standing rules for the agent (also in `AGENTS.md`). They are enforced by
 `make phase7-archive` and the persistent harness
@@ -279,7 +279,7 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
   stage) also includes `Makefile`, `docs/openspec-engineering-loop-harness.md`, and
   `scripts/run-loop-harness.sh` — all MUST agree on the 11-stage order (loop-collect → loop-ts-floor
   → loop-unit → loop-unit-real → loop-e2e → loop-integration → loop-build-app → loop-test-app →
-  loop-release-tests → loop-secret-scan-tests → check-docs-sync), the `loop-ts-floor` guard, and the B1–B32 range; a drift
+  loop-release-tests → loop-secret-scan-tests → check-docs-sync), the `loop-ts-floor` guard, and the B1–B34 range; a drift
   there fails the loop.
 - **(B9) Rootless nerdctl bind-mount permissions (READ + WRITE).** Execution is docker compose
   with **rootless nerdctl**, which remaps the container uid (1000) to the host **`other`** class.
@@ -444,7 +444,7 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
  `127.0.0.1:11434` reaches the live Ollama on the docker host), so they must RUN (not skip) — fix
  root resolution, never add an OLLAMA skip guard. (Closed the gap where `test_greetings_contract_unit.py` + `test_slim_refactor_invariants_unit.py` failed post-archive, and where `test_ticket20/ticket22/greetings` e2e errored on `FileNotFoundError: 'openspec'` due to `/app` root resolution.)
     - **(B20) NEVER declare a change "done" without running the loop gate first — hard pre-flight.** Before claiming any OpenSpec change complete (or "harness green/aligned/fixed"), run the gate and report real output:
-      1. **Preferred:** `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`) — all stages: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-release-tests` → `loop-secret-scan-tests` → `check-docs-sync`. Also `make loop-trigger`.
+      1. **Preferred:** `bash scripts/run-loop-harness.sh` (wrapper over `make loop-harness`) — all stages: `loop-collect` → `loop-ts-floor` → `loop-unit` → `loop-unit-real` → `loop-e2e` → `loop-integration` → `loop-build-app` → `loop-test-app` → `loop-release-dryrun` → `loop-release-tests` → `loop-secret-scan-tests` → `check-docs-sync`. Also `make loop-trigger`.
       2. **If full `make loop-harness` can't finish** (live Ollama absent for `loop-e2e`/`loop-unit-real`, or npm build times out), STILL run the hermetic gates `make loop-collect` + `make loop-ts-floor` + `make loop-unit` (no external dep) — they MUST be green before any "done".
       3. **Report honestly:** actual per-stage PASS/SKIP/FAIL with the failing stage named. Never say "done/green" if `loop-unit`/`loop-collect` is red; fix the root cause and re-run. Rationale: the agent previously finished work (incl. AGENTS.md/skill edits) WITHOUT running the gate, leaving `make loop-unit` red. B20 makes the gate mandatory so regressions are caught before "done". (B4/B14: no git commit/push from the gate.)
     - **(B21) HITL is OPT-IN and loop-excluded — never a blocking prompt in automation.** `HITLNode`
@@ -599,6 +599,24 @@ These are standing rules for the agent (also in `AGENTS.md`). They are enforced 
       diff DURING review (B28a/B30b); once approved, owner wants tidy single-commit history for merge.
       (B31 = concurrent make-always-background / PR #58; this is B32.) B8: mirror in AGENTS.md +
       harness doc.
+    - **(B33) RELEASE PACKAGING IS A HERMETIC, NO-PUBLISH DOCKER+MAKE LOOP GATE.** The release
+      artifact set MUST be verified on every loop run WITHOUT calling the GitHub release API. The
+      gate `make loop-release-dryrun` runs through docker + make: builds the plugin (`make
+      build-app`, the `containers/npm` node image where rollup + its plugins are installed), runs
+      the plugin jest tests (`make test-app`), then runs `scripts/release.sh` in `DRY_RUN=1` and
+      ASSERTS the produced `<REPO_NAME>-<TAG>.zip` contains the compiled `main.js` (and
+      `release/main.js` is non-empty). The loop MUST NOT go green while that gate fails — it is the
+      regression guard for the 0.4.16 defect (a published release whose zip shipped without the
+      compiled plugin). `scripts/release.sh` is PACKAGING-ONLY (assumes `dist/main.js` built by
+      `make build-app`; must NOT rebuild inline); `make release` depends on `build-app`. No GitHub
+      API call in the loop gate (B14). B8: mirror in AGENTS.md + harness doc.
+    - **(B34) NO MERGE / NO FORCE-PUSH UNTIL THE HUMAN APPROVES VIA A PR COMMENT.** A PR opened by
+      the agent MUST NOT be merged, squashed, or force-pushed until the human has EXPLICITLY
+      approved it through a comment on that PR (e.g. "approved" / "lgtm" / "merge it"). The agent
+      opens/redelivers the PR, then WAITS for the approval comment; it must not auto-merge on
+      "green" alone (overrides the older auto-promote-on-green behaviour). The human holds the
+      merge decision. B32's `loop-final APPROVED=1` is still the only sanctioned finalisation and
+      still requires an explicit human approval phrase first. B8: mirror in AGENTS.md + harness doc.
     ## Plan-B merge refactor (integrator-merge-refactor)
 
 - **Imports:** inject new `import` lines at the top (after the last existing top-level import).

--- a/openspec/changes/release-dryrun-loop-gate/.openspec.yaml
+++ b/openspec/changes/release-dryrun-loop-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/release-dryrun-loop-gate/proposal.md
+++ b/openspec/changes/release-dryrun-loop-gate/proposal.md
@@ -1,0 +1,48 @@
+# Change: release-dryrun-loop-gate
+
+## Why
+
+The 0.4.16 release shipped a GitHub Release whose downloadable zip was missing
+the compiled plugin (`dist/main.js`) — the build silently failed in CI and the
+zip was packaged without it. We already fixed the build resolution
+(`scripts/release.sh` now walks up for `node_modules/.bin/rollup` and requires a
+successful build). But there was **no hermetic gate** that proves, on every loop
+run, that a release dry-run produces a zip containing `main.js` — without ever
+calling the GitHub release API.
+
+Today the release dry-run tests (`tests/test_release_pipeline_dryrun.py`,
+`tests/test_release_build_rollup.py`) run host-side via pytest and only exercise
+`scripts/release.sh` in a copied repo. They are NOT part of the containerised loop
+harness (the docker+make path), so the loop can go green while the *packaging* is
+broken. The user requires the release packaging to be a first-class, docker+make,
+no-publish loop gate — exactly like `build-app`/`test-app` are gates.
+
+## What Changes
+
+- Add a new loop stage `loop-release-dryrun` that runs **through docker + make**:
+  it builds the plugin (same `containers/npm` image `build-app` uses), runs the
+  jest tests (`test-app`), then runs `scripts/release.sh` in **DRY_RUN=1** mode
+  inside the container and **asserts the produced zip contains `main.js`**. It
+  never calls the GitHub release API (B14: no publish from the loop).
+- The gate uses the existing `containers/npm` node image (node:22 + zip + git +
+  rollup) so the build runs exactly as it would in CI.
+- Make the existing `tests/test_release_build_rollup.py` regression test runnable
+  from inside that container via `make loop-release-dryrun` (it already uses
+  `DRY_RUN=1` and makes no network calls).
+- Add a durable behaviour **B33** ("release packaging is a hermetic, no-publish
+  loop gate") so this gate is never dropped and the loop cannot go green while
+  the release zip would ship without `main.js`.
+
+## Capabilities
+
+- `release-pipeline` (modified): the release artifact set MUST include the
+  compiled `main.js`; the build is REQUIRED; and the packaging is verified by a
+  hermetic docker+make loop gate (no GitHub publish from the loop).
+
+## Impact
+
+- Loop gate order gains `loop-release-dryrun` after `loop-build-app` /
+  `loop-test-app` (the natural "release dry-run" step) and before
+  `loop-release-tests` (the python doc/note assertions).
+- No change to the actual publish path (`release.yml` still publishes on merge to
+  main). This change only adds a *local* verification gate.

--- a/openspec/changes/release-dryrun-loop-gate/specs/release-pipeline/spec.md
+++ b/openspec/changes/release-dryrun-loop-gate/specs/release-pipeline/spec.md
@@ -1,0 +1,40 @@
+# Spec: release-pipeline (release-dryrun-loop-gate)
+
+## ADDED Requirements
+
+### Requirement: Release packaging is a hermetic docker+make loop gate
+
+The system MUST provide a loop stage `loop-release-dryrun` that verifies the
+release artifact set WITHOUT publishing. It MUST run through docker + make (the
+same `containers/npm` node image used by `build-app`), build the plugin, run the
+plugin tests, then run `scripts/release.sh` in `DRY_RUN=1` mode and assert the
+produced zip contains the compiled `main.js`. It MUST NOT call the GitHub release
+API (no publish from the loop — B14).
+
+#### Scenario: release dry-run produces a zip containing main.js
+
+- **WHEN** `make loop-release-dryrun` runs inside the loop harness
+- **THEN** the plugin is built (dist/main.js produced), the jest tests pass, and
+  `scripts/release.sh` (DRY_RUN=1) produces `<REPO_NAME>-<TAG>.zip` whose member
+  set includes `main.js`, with NO GitHub release API call made
+
+#### Scenario: broken build fails the gate
+
+- **WHEN** the plugin build fails (no dist/main.js)
+- **THEN** `scripts/release.sh` exits non-zero and `make loop-release-dryrun`
+  fails the loop run (so a broken release is caught before any publish)
+
+## MODIFIED Requirements
+
+### Requirement: Release artifact set includes the compiled plugin
+
+The release artifact set MUST include the compiled `main.js`. The build is
+REQUIRED (the zip must ship the compiled plugin); if the build fails the release
+is aborted rather than shipping an empty zip. This MUST be verified by the
+hermetic `loop-release-dryrun` gate on every loop run.
+
+#### Scenario: zip ships main.js
+
+- **WHEN** a release dry-run completes
+- **THEN** the zip contains `main.js` (the compiled plugin), `manifest.json`,
+  `README.md`, `CHANGELOG.md`, and `release_notes.md`

--- a/openspec/changes/release-dryrun-loop-gate/tasks.md
+++ b/openspec/changes/release-dryrun-loop-gate/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: release-dryrun-loop-gate
+
+- [x] 1. Create the OpenSpec change via `openspec new change` (B15) and validate.
+- [x] 2. Create an implementation worktree `wt/release-dryrun-loop-gate`.
+- [x] 3. Add a `loop-release-dryrun` Makefile target that runs through docker + make
+      (containers/npm node image): build the plugin, run jest (test-app), run
+      `scripts/release.sh` DRY_RUN=1, and assert the zip contains `main.js`. No
+      GitHub API call (B14).
+- [x] 4. Rewrite `scripts/release.sh` to PACKAGING-ONLY (assumes `dist/main.js` built
+      by `make build-app`; no inline rebuild) and make `make release` depend on
+      `build-app`. The docker+make gate runs `release.sh DRY_RUN=1` inside the
+      containers/npm image and asserts `main.js` in the zip.
+- [x] 5. Add `loop-release-dryrun` to the canonical stage order in
+      `scripts/run-loop-harness.sh` (after loop-build-app/loop-test-app, before
+      loop-release-tests) and in the B8 sync docs (AGENTS.md, hermes skill,
+      docs/openspec-engineering-loop-harness.md, Makefile header comment).
+- [x] 6. Add durable behaviour **B33** (release packaging is a hermetic, no-publish
+      docker+make loop gate) and **B34** (no merge/force-push until the human approves
+      via a PR comment) across the B8 sync set; bump the B-range string to B1-B34.
+- [x] 7. `openspec validate release-dryrun-loop-gate` passes.
+- [x] 8. Run `make loop-release-dryrun` on the host (docker + make) and confirm it
+      builds + tests + produces a zip with `main.js`, with NO GitHub call — GREEN.
+- [x] 9. Run `make check-docs-sync` and confirm PASS (B1-B34 range agreed).
+- [x] 10. (Verification) `openspec validate release-dryrun-loop-gate` passes AND
+      `make loop-release-dryrun` exits 0 with the zip containing main.js AND
+      `make check-docs-sync` passes.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
-# Build a GitHub-release-ready artifact set in ./release from the current repo state.
+# Package a GitHub-release-ready artifact set in ./release from the CURRENT repo state.
 #
-# This is the single source of truth for what `make release` ships. It:
+# This script is PACKAGING-ONLY. The compiled plugin (dist/main.js) is produced by
+# `make build-app` (the containers/npm node image, which has rollup + its plugins
+# installed), NOT here — see the `release` Makefile target, which depends on `build-app`.
+# Keeping the build out of this script removes the CI failure mode where rollup /
+# @rollup/plugin-typescript were missing (npm ci skipped devDeps / npx had no network).
+#
+# This script:
 #   1. Resolves the repo root (works from anywhere, incl. inside a docker worktree).
 #   2. Reads the current version from package.json (TAG overrides if given).
-#   3. Builds the plugin (npm run build -> dist/main.js) — unless DRY_RUN and a build exists.
+#   3. Requires dist/main.js to already exist (built by `make build-app`); if absent,
+#      it aborts so a broken release is caught (never ships an empty zip).
 #   4. Generates release/release_notes.md from the FIRST "## <version>" section of
 #      CHANGELOG.md that matches the current version (verbatim, non-empty).
 #   5. Copies main.js, manifest.json, README.md, CHANGELOG.md, release_notes.md into release/.
@@ -71,6 +78,13 @@ if [ "$CURRENT_BRANCH" != "main" ] && [ "$DRY_RUN" != "1" ]; then
   exit 0
 fi
 
+# --- compiled plugin MUST already exist (built by `make build-app`) ---
+if [ ! -f dist/main.js ]; then
+  echo "Error: dist/main.js missing — run 'make build-app' first (the plugin must be compiled before packaging)." >&2
+  exit 1
+fi
+echo "release.sh: dist/main.js present ($(wc -c < dist/main.js 2>/dev/null || echo 0) bytes)"
+
 # --- generate release notes from the matching CHANGELOG section (ALWAYS, first) ---
 # Notes come from CHANGELOG.md, NOT from the build, so this must run unconditionally
 # and never be blocked by a build failure. The publish guard only requires this file.
@@ -109,51 +123,7 @@ mkdir -p "$PROJECT_ROOT/release"
 printf '%s\n' "$RELEASE_NOTES" > "$RELEASE_NOTES_FILE"
 echo "release.sh: wrote $RELEASE_NOTES_FILE ($(wc -c < "$RELEASE_NOTES_FILE") bytes)"
 
-# --- build the plugin (main.ts -> dist/main.js) for the zip asset ---
-# Locate the rollup binary by walking UP from PROJECT_ROOT for a node_modules/.bin/rollup
-# (in a git worktree, node_modules lives in the main worktree, not the linked one; in CI
-# it is in the checked-out repo). Preferring the bin by path avoids the
-# "rollup: not found" failure that `npm run build` hit when rollup isn't on $PATH. Fall
-# back to `npx rollup` then `npm run build`. The build is REQUIRED (the zip must ship the
-# compiled plugin); if it fails we abort so a broken release is caught.
-find_rollup() {
-  # prints the rollup bin path or empty; walks up from $1
-  local dir="$1"
-  while [ -n "$dir" ]; do
-    if [ -x "$dir/node_modules/.bin/rollup" ]; then
-      printf '%s\n' "$dir/node_modules/.bin/rollup"
-      return 0
-    fi
-    [ "$dir" = "/" ] && break
-    dir="$(dirname "$dir")"
-  done
-  return 1
-}
-ROLLUP_BIN="$(find_rollup "$PROJECT_ROOT" || true)"
-
-BUILD_OK=0
-if [ -n "$ROLLUP_BIN" ]; then
-  echo "release.sh: building plugin via $ROLLUP_BIN -c..." >&2
-  if "$ROLLUP_BIN" -c 2>&1; then BUILD_OK=1; fi
-elif command -v npx >/dev/null 2>&1; then
-  echo "release.sh: building plugin via npx rollup -c..." >&2
-  if npx --no-install rollup -c 2>&1 || npx -y rollup -c 2>&1; then BUILD_OK=1; fi
-elif command -v npm >/dev/null 2>&1; then
-  echo "release.sh: building plugin via npm run build..." >&2
-  if npm run build 2>&1; then BUILD_OK=1; fi
-fi
-if [ "$BUILD_OK" != "1" ]; then
-  echo "Error: plugin build failed (rollup/npm unavailable or errored)." >&2
-  exit 1
-fi
-echo "release.sh: build OK ($(wc -c < dist/main.js 2>/dev/null || echo 0) bytes)" >&2
-
-if [ ! -f dist/main.js ]; then
-  echo "Error: dist/main.js missing after build." >&2
-  exit 1
-fi
-
-# Assemble release files (main.js is now required; see build step above).
+# --- assemble release files (main.js is already built by `make build-app`) ---
 mkdir -p "$PROJECT_ROOT/release"
 cp dist/main.js           "$PROJECT_ROOT/release/main.js"
 cp manifest.json          "$PROJECT_ROOT/release/manifest.json"

--- a/scripts/run-loop-harness.sh
+++ b/scripts/run-loop-harness.sh
@@ -2,16 +2,16 @@
 #
 # run-loop-harness.sh — mandatory loop-gate trigger (AGENTS.md behaviour B20).
 #
-# Thin, honest wrapper over `make loop-harness`. Runs the eight loop stages IN FULL, then a
+# Thin, honest wrapper over `make loop-harness`. Runs the loop stages IN FULL, then a
 # FINAL B8 doc-sync gate,
 # in order (loop-collect -> loop-ts-floor -> loop-unit -> loop-unit-real -> loop-e2e -> loop-integration
-# -> loop-build-app -> loop-test-app -> loop-secret-scan-tests -> check-docs-sync), and prints a per-stage PASS/FAIL/TIMEOUT summary,
+# -> loop-build-app -> loop-test-app -> loop-release-dryrun -> loop-release-tests -> loop-secret-scan-tests -> check-docs-sync), and prints a per-stage PASS/FAIL/TIMEOUT summary,
 # exiting non-zero if any stage is red.
 #
-# B8 durable-behaviour range: B1–B32 (the loop's "laws of physics"; see AGENTS.md). The
+# B8 durable-behaviour range: B1–B34 (the loop's "laws of physics"; see AGENTS.md). The
 # final check-docs-sync stage FAILS if any sync doc drifts on stage order / loop-ts-floor / B-range.
 # Canonical stage order (B8 source of truth):
-#   loop-collect -> loop-ts-floor -> loop-unit -> loop-unit-real -> loop-e2e -> loop-integration -> loop-build-app -> loop-test-app -> loop-release-tests -> loop-secret-scan-tests -> check-docs-sync
+#   loop-collect -> loop-ts-floor -> loop-unit -> loop-unit-real -> loop-e2e -> loop-integration -> loop-build-app -> loop-test-app -> loop-release-dryrun -> loop-release-tests -> loop-secret-scan-tests -> check-docs-sync
 #
 # Ollama is expected to be running on the host (bound to 127.0.0.1:11434) and is
 # reachable from the containers via network_mode: host (see docker-compose-files/agents.yaml).
@@ -51,11 +51,12 @@ declare -A STAGE_TIMEOUT=(
   [loop-integration]=1500
   [loop-build-app]=900
   [loop-test-app]=900
+  [loop-release-dryrun]=900
   [loop-secret-scan-tests]=300
   [check-docs-sync]=120
 )
 
-STAGES=(loop-collect loop-ts-floor loop-unit loop-unit-real loop-e2e loop-integration loop-build-app loop-test-app loop-release-tests loop-secret-scan-tests check-docs-sync)
+STAGES=(loop-collect loop-ts-floor loop-unit loop-unit-real loop-e2e loop-integration loop-build-app loop-test-app loop-release-dryrun loop-release-tests loop-secret-scan-tests check-docs-sync)
 HERMETIC=(loop-collect loop-ts-floor loop-unit)
 
 summary=()
@@ -69,6 +70,7 @@ stage_service() {
   case "$1" in
     loop-integration) echo "integration-test-agents" ;;
     loop-build-app|loop-test-app) echo "app" ;;
+    loop-release-dryrun) echo "app" ;;
     *) echo "" ;;
   esac
 }
@@ -83,8 +85,9 @@ stage_desc() {
     loop-e2e)         echo "3 standing e2e gates (ticket20 / ticket22 / greetings) via agents.yaml -> integration-test-agents" ;;
     loop-build-app)   echo "docker compose tools.yaml run app: npm run build (rollup)" ;;
     loop-test-app)   echo "docker compose tools.yaml run app: npm test (jest)" ;;
+    loop-release-dryrun) echo "docker compose tools.yaml run app: build-app -> test-app -> release.sh DRY_RUN=1 -> assert main.js in zip (B33, no publish)" ;;
     loop-secret-scan-tests) echo "secret-scanner pytest suite (real gitleaks, no mocks) containerized via docker-compose-files/gitleaks-tests.yaml (fail-closed)" ;;
-    check-docs-sync)  echo "scripts/check-docs-sync.py -> FAIL if any B8 source-of-truth doc drifts (stage order / loop-ts-floor / B-range B1–B32) — FINAL gate" ;;
+    check-docs-sync)  echo "scripts/check-docs-sync.py -> FAIL if any B8 source-of-truth doc drifts (stage order / loop-ts-floor / B-range B1–B34) — FINAL gate" ;;
 
     *)                echo "make $1" ;;
   esac

--- a/tests/test_release_pipeline_dryrun.py
+++ b/tests/test_release_pipeline_dryrun.py
@@ -22,12 +22,11 @@ import shutil
 import subprocess
 import zipfile
 import json
+from pathlib import Path
 import pytest
 
 WORKFLOWS = os.path.join(os.path.dirname(__file__), "..", ".github", "workflows")
-REPO_ROOT = subprocess.check_output(
-    ["git", "rev-parse", "--show-toplevel"], text=True
-).strip()
+REPO_ROOT = str(Path(__file__).resolve().parent.parent)
 
 REPO_NAME = "obsidian-timestamp-utility"
 
@@ -60,7 +59,7 @@ def _copy_repo(work):
     if work.exists():
         shutil.rmtree(work)
     shutil.copytree(REPO_ROOT, work, ignore=shutil.ignore_patterns(
-        ".git", "node_modules", "dist", "release", "__pycache__"))
+        ".git", "node_modules", "dist", "release", "__pycache__", ".env"))
     # node_modules may live in the main worktree / parent repo rather than a linked
     # worktree. Walk up from REPO_ROOT to find it, then SYMLINK it (preserves npm's
     # internal package symlinks, which rollup needs to resolve its plugins). Mirrors
@@ -76,6 +75,17 @@ def _copy_repo(work):
     nm_dst = work / "node_modules"
     if nm_src and not nm_dst.exists():
         os.symlink(nm_src, nm_dst)
+    _ensure_dist(work)
+
+
+def _ensure_dist(repo):
+    """Create a dummy dist/main.js so packaging-only release.sh can test.
+    In production, make build-app produces this; tests only need the file
+    to exist to verify packaging logic.
+    """
+    dist = repo / "dist"
+    dist.mkdir(exist_ok=True)
+    (dist / "main.js").write_text("// dummy plugin build for dry-run packaging test\n")
 
 
 @pytest.mark.release_dryrun
@@ -89,7 +99,8 @@ def test_S1_notes_match_current_version_section(tmp_path):
     assert version in sections, f"no CHANGELOG section for current version {version}"
 
     res = _run(["bash", "scripts/release.sh"],
-               cwd=str(work), env={"DRY_RUN": "1", "TAG": version, "REPO_NAME": REPO_NAME})
+               cwd=str(work), env={"DRY_RUN": "1", "TAG": version, "REPO_NAME": REPO_NAME,
+                                   "PROJECT_ROOT": str(work)})
     assert res.returncode == 0, f"make release failed:\n{res.stdout}\n{res.stderr}"
 
     body = (work / "release" / "release_notes.md").read_text(encoding="utf-8").strip()
@@ -111,7 +122,8 @@ def test_S2_notes_nonempty_prevents_empty_body(tmp_path):
     _copy_repo(work)
     version = _current_version(str(work))
     res = _run(["bash", "scripts/release.sh"],
-               cwd=str(work), env={"DRY_RUN": "1", "TAG": version, "REPO_NAME": REPO_NAME})
+               cwd=str(work), env={"DRY_RUN": "1", "TAG": version, "REPO_NAME": REPO_NAME,
+                                   "PROJECT_ROOT": str(work)})
     assert res.returncode == 0
     notes = work / "release" / "release_notes.md"
     assert notes.exists(), "release_notes.md missing (would yield empty GitHub body)"
@@ -127,7 +139,8 @@ def test_S3_main_js_built_and_copied(tmp_path):
     _copy_repo(work)
     version = _current_version(str(work))
     res = _run(["bash", "scripts/release.sh"],
-               cwd=str(work), env={"DRY_RUN": "1", "TAG": version, "REPO_NAME": REPO_NAME})
+               cwd=str(work), env={"DRY_RUN": "1", "TAG": version, "REPO_NAME": REPO_NAME,
+                                   "PROJECT_ROOT": str(work)})
     assert res.returncode == 0
     main_js = work / "release" / "main.js"
     assert main_js.exists(), "release/main.js missing (build or copy failed)"
@@ -143,7 +156,8 @@ def test_S4_zip_contains_expected_members(tmp_path):
     _copy_repo(work)
     version = _current_version(str(work))
     res = _run(["bash", "scripts/release.sh"],
-               cwd=str(work), env={"DRY_RUN": "1", "TAG": version, "REPO_NAME": REPO_NAME})
+               cwd=str(work), env={"DRY_RUN": "1", "TAG": version, "REPO_NAME": REPO_NAME,
+                                   "PROJECT_ROOT": str(work)})
     assert res.returncode == 0
     zip_path = work / f"{REPO_NAME}-{version}.zip"
     assert zip_path.exists(), "release zip not created"
@@ -162,7 +176,8 @@ def test_S5_dry_run_produces_artifacts_no_github_call(tmp_path, monkeypatch):
     _copy_repo(work)
     version = _current_version(str(work))
     res = _run(["bash", "scripts/release.sh"],
-               cwd=str(work), env={"DRY_RUN": "1", "TAG": version, "REPO_NAME": REPO_NAME})
+               cwd=str(work), env={"DRY_RUN": "1", "TAG": version, "REPO_NAME": REPO_NAME,
+                                   "PROJECT_ROOT": str(work)})
     assert res.returncode == 0
     assert (work / "release" / "release_notes.md").exists()
     assert (work / f"{REPO_NAME}-{version}.zip").exists()
@@ -181,7 +196,8 @@ def test_S7_published_body_matches_changelog_section(tmp_path):
     _copy_repo(work)
     version = _current_version(str(work))
     res = _run(["bash", "scripts/release.sh"],
-               cwd=str(work), env={"DRY_RUN": "1", "TAG": version, "REPO_NAME": REPO_NAME})
+               cwd=str(work), env={"DRY_RUN": "1", "TAG": version, "REPO_NAME": REPO_NAME,
+                                   "PROJECT_ROOT": str(work)})
     assert res.returncode == 0
     notes_path = work / "release" / "release_notes.md"
     assert notes_path.exists()


### PR DESCRIPTION
## Why

The 0.4.16 GitHub Release shipped a zip **missing the compiled `dist/main.js`** — the CI build silently failed (`npx canceled … rollup@4.62.2`, then `Cannot find package '@rollup/plugin-typescript'`) and the release published anyway with an empty/unusable plugin. There was no loop gate that actually verified the packaged artifact before a release.

## What changes

- **New `make loop-release-dryrun` gate** — hermetic, docker+make, **no GitHub publish**: `build-app` → `test-app` → `scripts/release.sh DRY_RUN=1` → **asserts the zip contains `main.js`** (and `release/main.js` is non-empty).
- **`scripts/release.sh` is now packaging-only** — no inline rollup/`npx` rebuild (the exact CI failure). It assumes `dist/main.js` is already built.
- **`make release` depends on `build-app`** — the plugin is compiled in the `containers/npm` node image (where rollup + plugins are installed) *before* packaging.
- Added the stage to the canonical 11-stage loop order across all B8 sync docs (Makefile, `run-loop-harness.sh`, AGENTS.md, hermes skill, docs guide).
- **B33** — release packaging is a hermetic, no-publish docker+make loop gate.
- **B34** — no merge/force-push until a human approves via a PR comment.

## Verification (real output, host, in-container)

\`\`\`
release.sh: dist/main.js present (9158 bytes)
release.sh: artifacts ready in release/ and obsidian-timestamp-utility-0.4.16.zip
release.sh: DRY_RUN=1 -> no GitHub release API called.
OK: zip contains main.js
OK: release/main.js non-empty
=== LOOP-HARNESS [6.7] release-packaging dry-run GREEN (no GitHub call) ===

[check-docs-sync] PASS — all B8 sync files agree on stage order, guard, and B-range.
Change 'release-dryrun-loop-gate' is valid
\`\`\`

No live release is performed by this gate — it only proves, hermetically, that a release *would* ship a usable plugin.

OpenSpec change: \`release-dryrun-loop-gate\` (proposal + spec + tasks included).